### PR TITLE
feat(auth): runtime-aware UUID generation (Bun v7 / Node v4 fallback)

### DIFF
--- a/packages/auth/src/utils.test.ts
+++ b/packages/auth/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { assertProvider, hashPassword, hashToken, normalizeEmail, normalizeRoles, verifyPassword } from "./utils";
+import { assertProvider, hashPassword, hashToken, newId, normalizeEmail, normalizeRoles, verifyPassword } from "./utils";
 
 describe("auth utils", () => {
   test("normalizeEmail trims and lowercases", () => {
@@ -27,6 +27,16 @@ describe("auth utils", () => {
 
   test("hashToken is deterministic sha256", () => {
     expect(hashToken("token")).toBe("3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0");
+  });
+
+  test("newId returns RFC UUID", () => {
+    const id = newId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  test("newId can force v4", () => {
+    const id = newId("v4");
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
   });
 
   test("assertProvider accepts known providers and rejects unknown", () => {

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes, scryptSync, timingSafeEqual } from "node:crypto";
+import { createHash, randomBytes, randomUUID, scryptSync, timingSafeEqual } from "node:crypto";
 import type { OAuthProvider } from "./types";
 
 export function normalizeEmail(email: string): string {
@@ -40,8 +40,24 @@ export function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
 }
 
-export function newId(): string {
-  return Bun.randomUUIDv7();
+export type IdVersion = "v4" | "v7";
+
+export function newId(version: IdVersion = "v7"): string {
+  if (version === "v4") {
+    return randomUUID();
+  }
+
+  const bunRuntime = globalThis as typeof globalThis & {
+    Bun?: {
+      randomUUIDv7?: () => string;
+    };
+  };
+
+  if (typeof bunRuntime.Bun?.randomUUIDv7 === "function") {
+    return bunRuntime.Bun.randomUUIDv7();
+  }
+
+  return randomUUID();
 }
 
 export function assertProvider(provider: string): asserts provider is OAuthProvider {


### PR DESCRIPTION
## Summary
- make `newId()` runtime-aware so `@alesha-nov/auth` works on both Bun and Node.js
- add optional `version` parameter: `newId("v7")` (default) or `newId("v4")`
- keep default behavior as v7 on Bun (`Bun.randomUUIDv7()`), fallback to Node `crypto.randomUUID()` elsewhere
- add tests for default UUID shape and forced v4 behavior

## Why
Issue #7 asks to remove Bun-only UUID dependency while preserving compatibility and providing clear UUID-version control.

## Validation
- `bun run lint`
- `bun run test`

Closes #7
