### PR TITLE
feat(config): close #8 #9 #10 with JWT/OAuth config + migration bundle

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,13 +8,17 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./auth-migrations": {
+      "types": "./dist/auth-migrations.d.ts",
+      "import": "./dist/auth-migrations.js"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --external bun",
+    "build": "tsup src/index.ts src/auth-migrations.ts --format esm --dts --external bun",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src --ext .ts",
     "test": "bun test"

--- a/packages/config/src/auth-migrations.test.ts
+++ b/packages/config/src/auth-migrations.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { authMigrationsBundle } from "./auth-migrations";
+
+describe("authMigrationsBundle", () => {
+  test("has unique and ordered migration ids", () => {
+    const ids = authMigrationsBundle.map((m) => m.id);
+    const unique = new Set(ids);
+
+    expect(unique.size).toBe(ids.length);
+    expect(ids).toEqual([
+      "001_create_auth_users",
+      "002_create_auth_sessions",
+      "003_create_auth_oauth_accounts",
+      "004_create_auth_magic_link_tokens",
+    ]);
+  });
+});

--- a/packages/config/src/auth-migrations.ts
+++ b/packages/config/src/auth-migrations.ts
@@ -1,0 +1,63 @@
+import type { Migration } from "./index";
+
+export const authMigrationsBundle: Migration[] = [
+  {
+    id: "001_create_auth_users",
+    sql: `
+      CREATE TABLE IF NOT EXISTS auth_users (
+        id VARCHAR(36) PRIMARY KEY,
+        email VARCHAR(320) NOT NULL UNIQUE,
+        password_hash VARCHAR(255) NOT NULL,
+        name VARCHAR(255) NULL,
+        image VARCHAR(2048) NULL,
+        email_verified_at TIMESTAMP NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `,
+  },
+  {
+    id: "002_create_auth_sessions",
+    sql: `
+      CREATE TABLE IF NOT EXISTS auth_sessions (
+        id VARCHAR(36) PRIMARY KEY,
+        user_id VARCHAR(36) NOT NULL,
+        session_token_hash VARCHAR(128) NOT NULL UNIQUE,
+        expires_at TIMESTAMP NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES auth_users(id) ON DELETE CASCADE
+      )
+    `,
+  },
+  {
+    id: "003_create_auth_oauth_accounts",
+    sql: `
+      CREATE TABLE IF NOT EXISTS auth_oauth_accounts (
+        id VARCHAR(36) PRIMARY KEY,
+        user_id VARCHAR(36) NOT NULL,
+        provider VARCHAR(32) NOT NULL,
+        provider_account_id VARCHAR(255) NOT NULL,
+        provider_email VARCHAR(320) NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(provider, provider_account_id),
+        UNIQUE(user_id, provider),
+        FOREIGN KEY (user_id) REFERENCES auth_users(id) ON DELETE CASCADE
+      )
+    `,
+  },
+  {
+    id: "004_create_auth_magic_link_tokens",
+    sql: `
+      CREATE TABLE IF NOT EXISTS auth_magic_link_tokens (
+        token_hash VARCHAR(128) PRIMARY KEY,
+        user_id VARCHAR(36) NOT NULL,
+        expires_at TIMESTAMP NOT NULL,
+        used_at TIMESTAMP NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES auth_users(id) ON DELETE CASCADE
+      )
+    `,
+  },
+];

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, test } from "bun:test";
-import { resolveDBType } from "./index";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  authMigrationsBundle,
+  resolveDBType,
+  resolveJWTSecret,
+  resolveOAuthConfig,
+} from "./index";
+
+afterEach(() => {
+  delete process.env.AUTH_JWT_SECRET;
+  delete process.env.JWT_SECRET;
+  delete process.env.AUTH_OAUTH_GOOGLE_CLIENT_ID;
+  delete process.env.AUTH_OAUTH_GOOGLE_CLIENT_SECRET;
+  delete process.env.AUTH_OAUTH_GOOGLE_REDIRECT_URI;
+  delete process.env.AUTH_OAUTH_GITHUB_CLIENT_ID;
+  delete process.env.AUTH_OAUTH_GITHUB_CLIENT_SECRET;
+  delete process.env.AUTH_OAUTH_GITHUB_REDIRECT_URI;
+});
 
 describe("resolveDBType", () => {
   test("maps postgres alias", () => {
@@ -8,5 +24,53 @@ describe("resolveDBType", () => {
 
   test("throws on invalid value", () => {
     expect(() => resolveDBType("oracle")).toThrow();
+  });
+});
+
+describe("resolveJWTSecret", () => {
+  test("prefers explicit input", () => {
+    process.env.AUTH_JWT_SECRET = "env-secret";
+    expect(resolveJWTSecret("input-secret")).toBe("input-secret");
+  });
+
+  test("falls back to environment", () => {
+    process.env.AUTH_JWT_SECRET = "env-secret";
+    expect(resolveJWTSecret()).toBe("env-secret");
+  });
+
+  test("throws when missing", () => {
+    expect(() => resolveJWTSecret()).toThrow("Missing JWT secret");
+  });
+});
+
+describe("resolveOAuthConfig", () => {
+  test("returns provider configs from env", () => {
+    process.env.AUTH_OAUTH_GOOGLE_CLIENT_ID = "google-id";
+    process.env.AUTH_OAUTH_GOOGLE_CLIENT_SECRET = "google-secret";
+    process.env.AUTH_OAUTH_GOOGLE_REDIRECT_URI = "https://app.local/google/callback";
+
+    const oauth = resolveOAuthConfig();
+
+    expect(oauth.google).toEqual({
+      clientId: "google-id",
+      clientSecret: "google-secret",
+      redirectUri: "https://app.local/google/callback",
+    });
+    expect(oauth.github).toBeUndefined();
+  });
+
+  test("throws when provider config is incomplete", () => {
+    process.env.AUTH_OAUTH_GITHUB_CLIENT_ID = "github-id";
+    expect(() => resolveOAuthConfig()).toThrow("Incomplete github OAuth env");
+  });
+});
+
+describe("auth migrations bundle", () => {
+  test("contains required auth migration tables", () => {
+    const sql = authMigrationsBundle.map((m) => m.sql).join("\n");
+    expect(sql.includes("auth_users")).toBe(true);
+    expect(sql.includes("auth_sessions")).toBe(true);
+    expect(sql.includes("auth_oauth_accounts")).toBe(true);
+    expect(sql.includes("auth_magic_link_tokens")).toBe(true);
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,6 +13,33 @@ export interface Migration {
   sql: string;
 }
 
+export interface JWTConfig {
+  secret: string;
+  issuer?: string;
+  audience?: string;
+  expiresIn?: string;
+}
+
+export type SessionSameSite = "lax" | "strict" | "none";
+
+export interface SessionConfig {
+  cookieName: string;
+  ttlSeconds: number;
+  secure: boolean;
+  sameSite: SessionSameSite;
+}
+
+export interface OAuthProviderConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+export interface OAuthConfig {
+  google?: OAuthProviderConfig;
+  github?: OAuthProviderConfig;
+}
+
 export interface DatabaseClient {
   sql: SQL;
   config: DBConfig;
@@ -41,6 +68,56 @@ export function createDatabaseClient(config: DBConfig): DatabaseClient {
 
   return { sql, config };
 }
+
+function readEnv(keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+export function resolveJWTSecret(input?: string): string {
+  const secret = input?.trim() || readEnv(["AUTH_JWT_SECRET", "JWT_SECRET"]);
+  if (!secret) {
+    throw new Error("Missing JWT secret. Set AUTH_JWT_SECRET or JWT_SECRET.");
+  }
+  return secret;
+}
+
+function resolveOAuthProviderConfig(provider: "google" | "github"): OAuthProviderConfig | undefined {
+  const upper = provider.toUpperCase();
+  const clientId = readEnv([`AUTH_OAUTH_${upper}_CLIENT_ID`, `${upper}_CLIENT_ID`]);
+  const clientSecret = readEnv([
+    `AUTH_OAUTH_${upper}_CLIENT_SECRET`,
+    `${upper}_CLIENT_SECRET`,
+  ]);
+  const redirectUri = readEnv([
+    `AUTH_OAUTH_${upper}_REDIRECT_URI`,
+    `${upper}_REDIRECT_URI`,
+  ]);
+
+  if (!clientId && !clientSecret && !redirectUri) {
+    return undefined;
+  }
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new Error(
+      `Incomplete ${provider} OAuth env. Require CLIENT_ID, CLIENT_SECRET, and REDIRECT_URI.`
+    );
+  }
+
+  return { clientId, clientSecret, redirectUri };
+}
+
+export function resolveOAuthConfig(): OAuthConfig {
+  return {
+    google: resolveOAuthProviderConfig("google"),
+    github: resolveOAuthProviderConfig("github"),
+  };
+}
+
+export { authMigrationsBundle } from "./auth-migrations";
 
 export async function ensureMigrationsTable(client: DatabaseClient): Promise<void> {
   const tableSql = `


### PR DESCRIPTION
## Summary
- add JWTConfig and SessionConfig interfaces in `@alesha-nov/config`
- add `resolveJWTSecret()` helper with env fallback (`AUTH_JWT_SECRET`/`JWT_SECRET`)
- add OAuth config interfaces and `resolveOAuthConfig()` with env resolution for Google/GitHub
- add dedicated auth migration bundle export (`authMigrationsBundle`) and subpath export `@alesha-nov/config/auth-migrations`
- add tests for JWT secret resolution, OAuth config resolution, and migration bundle coverage

## Validation
- bun run lint
- bun run test

Closes #8
Closes #9
Closes #10
