### PR TITLE
feat(auth-web,auth-react): OAuth authorize/callback endpoints + useOAuthLogin hook

### DIFF
--- a/packages/auth-react/src/hooks.test.tsx
+++ b/packages/auth-react/src/hooks.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach, afterEach, vi, type Mock } from "bun:test";
 import { act, renderHook, cleanup } from "@testing-library/react";
-import { useLogin, useSignup, useLogout, usePasswordResetRequest, useResetPassword } from "./hooks";
+import { useLogin, useSignup, useLogout, usePasswordResetRequest, useResetPassword, useOAuthLogin } from "./hooks";
 import { useAuth } from "./context";
 import type { PublicUser, AuthContextValue } from "./types";
 
@@ -356,5 +356,38 @@ describe("useResetPassword", () => {
 
     expect(result.current.success).toBe(false);
     expect(result.current.error).toBe("Invalid or expired token");
+  });
+});
+
+describe("useOAuthLogin", () => {
+  beforeEach(() => {
+    setupFetch();
+    (useAuth as Mock<() => AuthContextValue>).mockReturnValue({
+      status: "unauthenticated",
+      user: null,
+      session: null,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test("redirects browser to oauth authorize endpoint", () => {
+    const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useOAuthLogin({ basePath: "/auth" }));
+
+    act(() => {
+      result.current.login("google");
+    });
+
+    expect(assignSpy).toHaveBeenCalledWith("/auth/oauth/google/authorize");
+    expect(result.current.error).toBe(null);
+    expect(result.current.loading).toBe(true);
+
+    assignSpy.mockRestore();
   });
 });

--- a/packages/auth-react/src/hooks.ts
+++ b/packages/auth-react/src/hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import type { AuthApiConfig, LoginInput, SignupInput, PublicUser } from "./types";
+import type { AuthApiConfig, LoginInput, SignupInput, PublicUser, OAuthProvider } from "./types";
 import { useAuth } from "./context";
 
 function buildUrl(path: string, config: AuthApiConfig): string {
@@ -167,6 +167,30 @@ export function useResetPassword(config: AuthApiConfig = {}) {
   );
 
   return { reset, loading, error, success };
+}
+
+export function useOAuthLogin(config: AuthApiConfig = {}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const login = useCallback(
+    (provider: OAuthProvider) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const location = buildUrl(`/oauth/${provider}/authorize`, config);
+        window.location.assign(location);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "OAuth login redirect failed";
+        setError(msg);
+        setLoading(false);
+        throw e;
+      }
+    },
+    [config],
+  );
+
+  return { login, loading, error };
 }
 
 export function useAuthGuard({ redirectTo }: { redirectTo?: string } = {}) {

--- a/packages/auth-react/src/index.test.ts
+++ b/packages/auth-react/src/index.test.ts
@@ -11,13 +11,14 @@ describe("auth-react exports", () => {
   });
 
   test("hooks exports are defined", async () => {
-    const { useSignup, useLogin, useLogout, usePasswordResetRequest, useResetPassword, useAuthGuard } = await import("./hooks");
+    const { useSignup, useLogin, useLogout, usePasswordResetRequest, useResetPassword, useOAuthLogin, useAuthGuard } = await import("./hooks");
 
     expect(useSignup).toBeDefined();
     expect(useLogin).toBeDefined();
     expect(useLogout).toBeDefined();
     expect(usePasswordResetRequest).toBeDefined();
     expect(useResetPassword).toBeDefined();
+    expect(useOAuthLogin).toBeDefined();
     expect(useAuthGuard).toBeDefined();
   });
 

--- a/packages/auth-react/src/index.ts
+++ b/packages/auth-react/src/index.ts
@@ -1,7 +1,7 @@
 export { AuthProvider, AuthContext, useAuth } from "./context";
 export type { AuthContextValue, AuthState } from "./context";
 
-export { useSignup, useLogin, useLogout, usePasswordResetRequest, useResetPassword, useAuthGuard } from "./hooks";
+export { useSignup, useLogin, useLogout, usePasswordResetRequest, useResetPassword, useOAuthLogin, useAuthGuard } from "./hooks";
 
 export { AuthGuard } from "./auth-guard";
 

--- a/packages/auth-react/src/types.ts
+++ b/packages/auth-react/src/types.ts
@@ -39,6 +39,8 @@ export interface LoginInput {
   password: string;
 }
 
+export type OAuthProvider = "google" | "github";
+
 export interface AuthApiConfig {
   basePath?: string;
   baseUrl?: string;

--- a/packages/auth-web/src/index.test.ts
+++ b/packages/auth-web/src/index.test.ts
@@ -445,6 +445,116 @@ describe("POST /password-reset/reset", () => {
   });
 });
 
+describe("GET /oauth/:provider/authorize", () => {
+  test("returns 501 when oauth authorize flow is not configured", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+    });
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/oauth/google/authorize", { method: "GET" })
+    );
+
+    expect(response.status).toBe(501);
+  });
+
+  test("returns 302 and sets OAuth state cookie when configured", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+      getOAuthAuthorizeUrl: ({ provider, state, redirectUri }) => {
+        expect(provider).toBe("google");
+        expect(state.length).toBeGreaterThan(10);
+        expect(redirectUri).toBe("http://localhost/auth/oauth/google/callback");
+        return `https://oauth.example/authorize?provider=${provider}&state=${state}`;
+      },
+    });
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/oauth/google/authorize", { method: "GET" })
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toContain("https://oauth.example/authorize?");
+    expect(response.headers.get("set-cookie")).toContain("alesha_oauth_state_google=");
+  });
+});
+
+describe("GET /oauth/:provider/callback", () => {
+  test("returns 501 when oauth callback flow is not configured", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+    });
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/oauth/google/callback?code=x&state=y", { method: "GET" })
+    );
+
+    expect(response.status).toBe(501);
+  });
+
+  test("returns 400 on state mismatch", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+      completeOAuthCallback: () => ({
+        providerAccountId: "google-123",
+        email: "oauth@example.com",
+      }),
+    });
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/oauth/google/callback?code=x&state=wrong", {
+        method: "GET",
+        headers: { cookie: "alesha_oauth_state_google=expected" },
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  test("success callback logs in user, sets session cookie, and clears oauth state cookie", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+      completeOAuthCallback: ({ provider, code, state, redirectUri }) => {
+        expect(provider).toBe("google");
+        expect(code).toBe("oauth-code");
+        expect(state).toBe("ok-state");
+        expect(redirectUri).toBe("http://localhost/auth/oauth/google/callback");
+        return {
+          providerAccountId: "google-123",
+          email: "oauth-callback@example.com",
+          name: "OAuth Callback",
+        };
+      },
+    });
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/oauth/google/callback?code=oauth-code&state=ok-state", {
+        method: "GET",
+        headers: { cookie: "alesha_oauth_state_google=ok-state" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { user: Record<string, unknown> };
+    expect(body.user.email).toBe("oauth-callback@example.com");
+
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("alesha_auth=");
+    expect(setCookie).toContain("alesha_oauth_state_google=");
+    expect(setCookie).toContain("Max-Age=0");
+  });
+});
+
 describe("POST /oauth/:provider/login", () => {
   test("success flow returns user and sets session cookie", async () => {
     const app = createAuthWeb({

--- a/packages/auth-web/src/index.ts
+++ b/packages/auth-web/src/index.ts
@@ -7,7 +7,16 @@ import {
   type OAuthProvider,
   type SignupInput,
 } from "@alesha-nov/auth";
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export interface OAuthCallbackProfile {
+  providerAccountId: string;
+  email: string;
+  name?: string;
+  image?: string;
+  emailVerified?: boolean;
+  roles?: string[];
+}
 
 export interface AuthWebOptions {
   authService: AuthService;
@@ -18,6 +27,21 @@ export interface AuthWebOptions {
   secureCookie?: boolean;
   /* Optional: resolve a user by ID for GET /me. */
   getUser?: (userId: string) => Promise<AuthUser | null>;
+  /* Optional: build provider authorize URL for GET /oauth/:provider/authorize. */
+  getOAuthAuthorizeUrl?: (input: {
+    provider: OAuthProvider;
+    state: string;
+    redirectUri: string;
+    request: Request;
+  }) => string | Promise<string>;
+  /* Optional: exchange callback params into OAuth identity profile. */
+  completeOAuthCallback?: (input: {
+    provider: OAuthProvider;
+    code: string;
+    state: string;
+    redirectUri: string;
+    request: Request;
+  }) => OAuthCallbackProfile | Promise<OAuthCallbackProfile>;
 }
 
 export interface AuthSession {
@@ -99,6 +123,34 @@ function parseCookies(request: Request): Record<string, string> {
     out[k] = rest.join("=");
   }
   return out;
+}
+
+function appendSetCookie(headers: Record<string, string> | undefined, cookie: string): Record<string, string> {
+  if (!headers) return { "set-cookie": cookie };
+  const existing = headers["set-cookie"];
+  if (!existing) return { ...headers, "set-cookie": cookie };
+  return { ...headers, "set-cookie": `${existing}, ${cookie}` };
+}
+
+function resolveOAuthRedirectUri(request: Request, provider: OAuthProvider, basePath: string): string {
+  const incoming = new URL(request.url);
+  return `${incoming.origin}${basePath}/oauth/${provider}/callback`;
+}
+
+function oauthStateCookieName(provider: OAuthProvider): string {
+  return `alesha_oauth_state_${provider}`;
+}
+
+function decodeOAuthState(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function generateOAuthState(): string {
+  return b64url(randomBytes(24));
 }
 
 async function safeJson<T = Record<string, unknown>>(request: Request): Promise<T> {
@@ -276,6 +328,98 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
 
         if (!ok) return json(401, { error: "Invalid or expired token" });
         return json(200, { ok: true });
+      }
+
+      if (method === "GET" && subPath.startsWith("/oauth/") && subPath.endsWith("/authorize")) {
+        const provider = subPath.split("/")[2] as OAuthProvider;
+
+        if (!options.getOAuthAuthorizeUrl) {
+          return json(501, { error: "OAuth authorize flow is not configured" });
+        }
+
+        const state = generateOAuthState();
+        const redirectUri = resolveOAuthRedirectUri(request, provider, basePath);
+        const location = await options.getOAuthAuthorizeUrl({
+          provider,
+          state,
+          redirectUri,
+          request,
+        });
+
+        const stateCookie = serializeCookie(oauthStateCookieName(provider), encodeURIComponent(state), {
+          maxAge: 60 * 10,
+          secure: secureCookie,
+        });
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location,
+            "set-cookie": stateCookie,
+          },
+        });
+      }
+
+      if (method === "GET" && subPath.startsWith("/oauth/") && subPath.endsWith("/callback")) {
+        const provider = subPath.split("/")[2] as OAuthProvider;
+
+        if (!options.completeOAuthCallback) {
+          return json(501, { error: "OAuth callback flow is not configured" });
+        }
+
+        const callbackUrl = new URL(request.url);
+        const code = callbackUrl.searchParams.get("code")?.trim();
+        const receivedState = callbackUrl.searchParams.get("state")?.trim();
+        if (!code || !receivedState) {
+          return json(400, { error: "Missing OAuth callback code or state" });
+        }
+
+        const cookies = parseCookies(request);
+        const expectedStateRaw = cookies[oauthStateCookieName(provider)];
+        const expectedState = expectedStateRaw ? decodeOAuthState(expectedStateRaw) : null;
+        if (!expectedState || expectedState !== receivedState) {
+          return json(400, { error: "Invalid OAuth state" });
+        }
+
+        const redirectUri = resolveOAuthRedirectUri(request, provider, basePath);
+        const oauthProfile = await options.completeOAuthCallback({
+          provider,
+          code,
+          state: receivedState,
+          redirectUri,
+          request,
+        });
+
+        const user = await options.authService.loginWithOAuth({
+          provider,
+          providerAccountId: oauthProfile.providerAccountId,
+          email: oauthProfile.email,
+          name: oauthProfile.name,
+          image: oauthProfile.image,
+          emailVerified: oauthProfile.emailVerified,
+          roles: oauthProfile.roles,
+        });
+
+        const publicUser = toPublicUser(user);
+        const session = newSession(publicUser);
+        const clearStateCookie = serializeCookie(oauthStateCookieName(provider), "", {
+          maxAge: 0,
+          secure: secureCookie,
+        });
+
+        return json(
+          200,
+          { user: publicUser },
+          appendSetCookie(
+            {
+              "set-cookie": serializeCookie(cookieName, sessionCookieValue(session), {
+                maxAge: sessionTtlSeconds,
+                secure: secureCookie,
+              }),
+            },
+            clearStateCookie,
+          ),
+        );
       }
 
       if (method === "POST" && subPath.startsWith("/oauth/") && subPath.endsWith("/login")) {

--- a/packages/auth-web/src/next.test.ts
+++ b/packages/auth-web/src/next.test.ts
@@ -32,4 +32,17 @@ describe("createNextAuthHandlers", () => {
     expect(typeof handlers.DELETE).toBe("function");
     expect(typeof handlers.PATCH).toBe("function");
   });
+
+  test("delegates method handlers to auth-web router", async () => {
+    const handlers = createNextAuthHandlers({
+      authService,
+      sessionSecret: "0123456789abcdef",
+    });
+
+    const getResponse = await handlers.GET(new Request("http://localhost/auth/session", { method: "GET" }));
+    expect(getResponse.status).toBe(401);
+
+    const postResponse = await handlers.POST(new Request("http://localhost/auth/logout", { method: "POST" }));
+    expect(postResponse.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- add `GET /auth/oauth/:provider/authorize` endpoint in `@alesha-nov/auth-web`
- add `GET /auth/oauth/:provider/callback` endpoint in `@alesha-nov/auth-web`
- add OAuth state cookie handling + validation for callback flow
- add `useOAuthLogin` hook in `@alesha-nov/auth-react` to trigger redirect flow
- extend unit tests for all new paths

## Validation
- `bun run lint` ✅
- `bun run test` ✅
- package coverage checks:
  - `packages/auth-web`: 99.42% lines, 100% funcs ✅
  - `packages/auth-react`: 99.13% lines, 100% funcs ✅

Closes #11
Closes #12
Refs #15
