### PR TITLE
chore: bump all packages from 0.1.0 to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alesha-node",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/auth-react/package.json
+++ b/packages/auth-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth-react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth-web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/config",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/email",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bump version for all 6 packages in the monorepo from `0.1.0` → `0.2.0`.

## Packages bumped

| Package | Old | New |
|---|---|---|
| `alesha-node` (root) | 0.1.0 | 0.2.0 |
| `@alesha-nov/config` | 0.1.0 | 0.2.0 |
| `@alesha-nov/auth` | 0.1.0 | 0.2.0 |
| `@alesha-nov/email` | 0.1.0 | 0.2.0 |
| `@alesha-nov/auth-web` | 0.1.0 | 0.2.0 |
| `@alesha-nov/auth-react` | 0.1.0 | 0.2.0 |

## Verification

- **Lint**: ✅ All packages pass
- **Tests**: ✅ 141/144 pass; 3 pre-existing failures in `@alesha-nov/auth` (migration ID ordering in `src/migrations.test.ts` / `src/index.test.ts` — unrelated to this bump)

## Notes

- Uses `workspace:*` for internal package references — no lockfile updates needed for version-only changes.
- `bun.lock` entries at `0.1.0` are external dependencies (`fs-extra`, `p-limit`, `yocto-queue`) — intentionally untouched.