### PR TITLE
ci: OIDC Trusted Publishing — remove NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write   # required for OIDC Trusted Publishing
 
 concurrency:
   group: release-${{ github.ref }}
@@ -29,11 +30,12 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Node.js for npm publish
+      - name: Setup Node.js for npm publish (OIDC Trusted Publishing)
         uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+          # No token secret needed — id-token: write triggers OIDC exchange
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -50,4 +52,4 @@ jobs:
           commit: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # No NPM_TOKEN — uses OIDC Trusted Publishing via id-token


### PR DESCRIPTION
## Summary

Switch the Release workflow from long-lived `NPM_TOKEN` secret to **OIDC Trusted Publishing** — no secret needed.

## Changes

| | Before | After |
|---|---|---|
| `permissions` | `id-token` not set | `id-token: write` added |
| `setup-node` `token` | `secrets.NPM_TOKEN` | omitted (OIDC exchange uses `id-token`) |
| `changesets/action` env | `NPM_TOKEN: secrets.NPM_TOKEN` | removed |

## npm-side requirement

Before this can publish successfully, each package must be registered as an OIDC publisher on npm:

> **Settings → Maintainers → Add Publisher → JuniYadi/alesha-nov**

For all 5 packages: `@alesha-nov/config`, `@alesha-nov/auth`, `@alesha-nov/email`, `@alesha-nov/auth-web`, `@alesha-nov/auth-react`

## After merge

1. Delete `NPM_TOKEN` secret from **GitHub repo → Settings → Secrets → Actions** (no longer needed)
2. Register OIDC publisher on npm for each package
3. Re-run Release workflow to confirm publish works