### PR TITLE
feat(auth): wire optional email auto-delivery into token issuance flows

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@alesha-nov/config": "workspace:*",
+        "@alesha-nov/email": "workspace:*",
       },
     },
     "packages/auth-react": {

--- a/docs/packages/auth.md
+++ b/docs/packages/auth.md
@@ -149,6 +149,53 @@ const user = await authService.verifyMagicLinkToken(token);
 // → AuthUser | null
 ```
 
+## Optional: Auto email delivery during token issuance
+
+`createAuthService` now supports optional email delivery for:
+- `issueMagicLinkToken`
+- `issuePasswordResetToken`
+- `issueEmailVerificationToken`
+
+When `options.email` is configured, the service will auto-send using `@alesha-nov/email` after token persistence succeeds.
+
+```ts
+import { createAuthService } from "@alesha-nov/auth";
+import { createSesProvider } from "@alesha-nov/email";
+
+const authService = await createAuthService(dbConfig, {
+  email: {
+    from: "noreply@example.com",
+    provider: createSesProvider({
+      region: "us-east-1",
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    }),
+
+    // optional per-flow overrides
+    magicLink: {
+      // enabled defaults to true when email provider exists
+      enabled: true,
+      render: ({ token, ttlSeconds }) => ({
+        subject: "Your sign-in link",
+        html: `<p>Use this link: <a href="${token}">Sign in</a></p>`,
+        text: `Use this link to sign in: ${token} (expires in ${ttlSeconds}s)`,
+      }),
+    },
+    passwordReset: {
+      to: ({ email }) => `security+${email}`,
+    },
+    emailVerification: {
+      enabled: false, // opt out for a specific flow
+    },
+  },
+});
+```
+
+### Behavior notes
+- If `options.email` is omitted, behavior is unchanged: token methods return raw tokens only.
+- If `options.email` is provided and a flow is not disabled, default templates are used from `@alesha-nov/email` (`magic-link`, `reset-password`, `verify-email`).
+- `render` and `to` let apps fully customize payloads/recipients per flow.
+
 ## Example: OAuth Login
 
 ```ts

--- a/docs/packages/email.md
+++ b/docs/packages/email.md
@@ -102,6 +102,8 @@ async function sendWelcomeEmail(to: string, name: string) {
 
 ## Auth Template Renderer (Magic Link / Verify Email / Reset Password)
 
+Used directly, or indirectly by `@alesha-nov/auth` auto-delivery mode when `createAuthService(..., { email })` is configured.
+
 ```ts
 import { renderAuthTemplate } from "@alesha-nov/email";
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -41,7 +41,8 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@alesha-nov/config": "workspace:*"
+    "@alesha-nov/config": "workspace:*",
+    "@alesha-nov/email": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,6 +3,11 @@ export { createAuthService } from "./service";
 export { assertProvider, hashPassword, hashToken, newId, normalizeEmail, normalizeRoles, verifyPassword } from "./utils";
 export { buildAuthUser, getUserById, getUserRolesInternal } from "./user-store";
 export type {
+  AuthEmailDeliveryContext,
+  AuthEmailDeliveryTemplate,
+  AuthEmailFlow,
+  AuthEmailFlowDeliveryOptions,
+  AuthEmailOptions,
   AuthService,
   AuthUser,
   EmailVerificationInput,

--- a/packages/auth/src/service.test.ts
+++ b/packages/auth/src/service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { EmailMessage } from "@alesha-nov/email";
 import { hashPassword } from "./utils";
 
 const sqlCalls: Array<{ text: string; values: unknown[] }> = [];
@@ -59,6 +60,58 @@ describe("createAuthService", () => {
     const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
 
     await expect(svc.issueMagicLinkToken({ email: "missing@example.com" })).rejects.toThrow("User not found");
+  });
+
+  test("issueMagicLinkToken auto-delivers email when provider is configured", async () => {
+    queue.push([{ id: "u-1" }], []);
+    const sentMessages: EmailMessage[] = [];
+    const svc = await createAuthService(
+      { type: "sqlite", url: ":memory:" },
+      {
+        email: {
+          from: "noreply@example.com",
+          provider: {
+            send: async (message) => {
+              sentMessages.push(message);
+              return { id: "msg-1" };
+            },
+          },
+        },
+      }
+    );
+
+    await svc.issueMagicLinkToken({ email: "User@Example.com", ttlSeconds: 120 });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.to).toBe("user@example.com");
+    expect(sentMessages[0]?.from).toBe("noreply@example.com");
+    expect(sentMessages[0]?.subject).toBe("Your Magic Link");
+  });
+
+  test("issueMagicLinkToken skips auto-delivery when flow is disabled", async () => {
+    queue.push([{ id: "u-1" }], []);
+    let sends = 0;
+    const svc = await createAuthService(
+      { type: "sqlite", url: ":memory:" },
+      {
+        email: {
+          from: "noreply@example.com",
+          provider: {
+            send: async () => {
+              sends += 1;
+              return { id: "msg-1" };
+            },
+          },
+          magicLink: {
+            enabled: false,
+          },
+        },
+      }
+    );
+
+    await svc.issueMagicLinkToken({ email: "user@example.com" });
+
+    expect(sends).toBe(0);
   });
 
   test("verifyMagicLinkToken returns null when token has been used", async () => {
@@ -141,6 +194,41 @@ describe("createAuthService", () => {
     expect(insertCall?.values).toContain("u-1");
   });
 
+  test("issuePasswordResetToken auto-delivers email with custom renderer", async () => {
+    queue.push([{ id: "u-1" }], []);
+    const sentMessages: EmailMessage[] = [];
+    const svc = await createAuthService(
+      { type: "sqlite", url: ":memory:" },
+      {
+        email: {
+          from: "noreply@example.com",
+          provider: {
+            send: async (message) => {
+              sentMessages.push(message);
+              return { id: "msg-2" };
+            },
+          },
+          passwordReset: {
+            to: (context) => `alerts+${context.email}`,
+            from: "security@example.com",
+            render: (context) => ({
+              subject: "Reset credentials",
+              html: `<p>${context.flow}:${context.token}</p>`,
+              text: `${context.flow}:${context.token}`,
+            }),
+          },
+        },
+      }
+    );
+
+    await svc.issuePasswordResetToken({ email: "user@example.com", ttlSeconds: 300 });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.to).toBe("alerts+user@example.com");
+    expect(sentMessages[0]?.from).toBe("security@example.com");
+    expect(sentMessages[0]?.subject).toBe("Reset credentials");
+  });
+
   test("issueEmailVerificationToken throws when user does not exist", async () => {
     queue.push([]);
     const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
@@ -158,6 +246,34 @@ describe("createAuthService", () => {
     const insertCall = sqlCalls.find((c) => c.text.includes("INSERT INTO auth_email_verification_tokens"));
     expect(insertCall).toBeDefined();
     expect(insertCall?.values).toContain("u-1");
+  });
+
+  test("issueEmailVerificationToken auto-delivers email and allows custom recipient", async () => {
+    queue.push([{ id: "u-1" }], []);
+    const sentMessages: EmailMessage[] = [];
+    const svc = await createAuthService(
+      { type: "sqlite", url: ":memory:" },
+      {
+        email: {
+          from: "noreply@example.com",
+          provider: {
+            send: async (message) => {
+              sentMessages.push(message);
+              return { id: "msg-3" };
+            },
+          },
+          emailVerification: {
+            to: () => ["user@example.com", "audit@example.com"],
+          },
+        },
+      }
+    );
+
+    await svc.issueEmailVerificationToken({ email: "user@example.com", ttlSeconds: 90 });
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.to).toEqual(["user@example.com", "audit@example.com"]);
+    expect(sentMessages[0]?.subject).toBe("Verify Your Email");
   });
 
   test("verifyEmailVerificationToken returns null when token not found", async () => {

--- a/packages/auth/src/service.ts
+++ b/packages/auth/src/service.ts
@@ -4,6 +4,9 @@ import { authMigrations } from "./migrations";
 import type {
   AuthAuditEvent,
   AuthAuditSink,
+  AuthEmailDeliveryContext,
+  AuthEmailFlow,
+  AuthEmailFlowDeliveryOptions,
   AuthService,
   AuthServiceOptions,
   AuthSession,
@@ -134,6 +137,71 @@ function createOAuthState(): string {
 async function emitAuditEvent(auditSink: AuthAuditSink | undefined, event: AuthAuditEvent): Promise<void> {
   if (!auditSink) return;
   await auditSink.emit(event);
+}
+
+function buildDefaultAuthEmail(flow: AuthEmailFlow, context: AuthEmailDeliveryContext): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const expiresInMinutes = Math.max(1, Math.ceil(context.ttlSeconds / 60));
+
+  if (flow === "magic-link") {
+    const subject = "Your Magic Link";
+    const html = `<p>Hi,</p><p>Click <a href="${context.token}">here</a> to sign in. This link expires in ${expiresInMinutes} minutes.</p>`;
+    const text = `Hi,\n\nVisit this link to sign in: ${context.token}\nExpires in ${expiresInMinutes} minutes.`;
+    return { subject, html, text };
+  }
+
+  if (flow === "password-reset") {
+    const subject = "Reset Your Password";
+    const html = `<p>Hi,</p><p>Your password reset code is: <strong>${context.token}</strong>. It expires in ${expiresInMinutes} minutes.</p>`;
+    const text = `Hi,\n\nPassword reset code: ${context.token}\nExpires in ${expiresInMinutes} minutes.`;
+    return { subject, html, text };
+  }
+
+  const subject = "Verify Your Email";
+  const html = `<p>Hi,</p><p>Your verification code is: <strong>${context.token}</strong>. It expires in ${expiresInMinutes} minutes.</p>`;
+  const text = `Hi,\n\nYour verification code: ${context.token}\nExpires in ${expiresInMinutes} minutes.`;
+  return { subject, html, text };
+}
+
+function resolveFlowOptions(options: AuthServiceOptions, flow: AuthEmailFlow): AuthEmailFlowDeliveryOptions | undefined {
+  const emailOptions = options.email;
+  if (!emailOptions) return undefined;
+
+  switch (flow) {
+    case "magic-link":
+      return emailOptions.magicLink;
+    case "password-reset":
+      return emailOptions.passwordReset;
+    case "email-verification":
+      return emailOptions.emailVerification;
+  }
+}
+
+async function maybeDeliverAuthTokenEmail(
+  options: AuthServiceOptions,
+  flow: AuthEmailFlow,
+  context: AuthEmailDeliveryContext
+): Promise<void> {
+  const emailOptions = options.email;
+  if (!emailOptions) return;
+
+  const flowOptions = resolveFlowOptions(options, flow);
+  if (flowOptions?.enabled === false) return;
+
+  const rendered = flowOptions?.render?.(context) ?? buildDefaultAuthEmail(flow, context);
+  const to = flowOptions?.to?.(context) ?? context.email;
+  const from = flowOptions?.from ?? emailOptions.from;
+
+  await emailOptions.provider.send({
+    from,
+    to,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
+  });
 }
 
 function pruneAttempts(attemptState: LoginAttemptState, windowSeconds: number): void {
@@ -382,8 +450,9 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
     },
 
     async issueMagicLinkToken(input: MagicLinkInput) {
+      const email = normalizeEmail(input.email);
       const rows = await client.sql`
-        SELECT id FROM auth_users WHERE email = ${normalizeEmail(input.email)} LIMIT 1
+        SELECT id FROM auth_users WHERE email = ${email} LIMIT 1
       `;
       const user = rows[0] as { id: string } | undefined;
       if (!user) throw new Error("User not found");
@@ -397,6 +466,14 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
         INSERT INTO auth_magic_link_tokens (token_hash, user_id, expires_at)
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
+
+      await maybeDeliverAuthTokenEmail(options, "magic-link", {
+        flow: "magic-link",
+        email,
+        token: rawToken,
+        ttlSeconds,
+        expiresAt,
+      });
 
       return rawToken;
     },
@@ -454,8 +531,9 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
     },
 
     async issuePasswordResetToken(input: PasswordResetInput) {
+      const email = normalizeEmail(input.email);
       const rows = await client.sql`
-        SELECT id FROM auth_users WHERE email = ${normalizeEmail(input.email)} LIMIT 1
+        SELECT id FROM auth_users WHERE email = ${email} LIMIT 1
       `;
       const user = rows[0] as { id: string } | undefined;
       if (!user) throw new Error("User not found");
@@ -469,6 +547,14 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
         INSERT INTO auth_password_reset_tokens (token_hash, user_id, expires_at)
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
+
+      await maybeDeliverAuthTokenEmail(options, "password-reset", {
+        flow: "password-reset",
+        email,
+        token: rawToken,
+        ttlSeconds,
+        expiresAt,
+      });
 
       return rawToken;
     },
@@ -537,8 +623,9 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
     },
 
     async issueEmailVerificationToken(input: EmailVerificationInput) {
+      const email = normalizeEmail(input.email);
       const rows = await client.sql`
-        SELECT id FROM auth_users WHERE email = ${normalizeEmail(input.email)} LIMIT 1
+        SELECT id FROM auth_users WHERE email = ${email} LIMIT 1
       `;
       const user = rows[0] as { id: string } | undefined;
       if (!user) throw new Error("User not found");
@@ -552,6 +639,14 @@ export async function createAuthService(dbConfig: DBConfig, options: AuthService
         INSERT INTO auth_email_verification_tokens (token_hash, user_id, expires_at)
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
+
+      await maybeDeliverAuthTokenEmail(options, "email-verification", {
+        flow: "email-verification",
+        email,
+        token: rawToken,
+        ttlSeconds,
+        expiresAt,
+      });
 
       return rawToken;
     },

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,3 +1,5 @@
+import type { EmailProvider } from "@alesha-nov/email";
+
 export interface SignupInput {
   email: string;
   password: string;
@@ -159,11 +161,43 @@ export interface AuthSessionStrategy {
   refreshSession(refreshToken: string): Promise<AuthSession | null>;
 }
 
+export type AuthEmailFlow = "magic-link" | "password-reset" | "email-verification";
+
+export interface AuthEmailDeliveryContext {
+  flow: AuthEmailFlow;
+  email: string;
+  token: string;
+  ttlSeconds: number;
+  expiresAt: string;
+}
+
+export interface AuthEmailDeliveryTemplate {
+  subject: string;
+  html?: string;
+  text?: string;
+}
+
+export interface AuthEmailFlowDeliveryOptions {
+  enabled?: boolean;
+  from?: string;
+  render?: (context: AuthEmailDeliveryContext) => AuthEmailDeliveryTemplate;
+  to?: (context: AuthEmailDeliveryContext) => string | string[];
+}
+
+export interface AuthEmailOptions {
+  provider: EmailProvider;
+  from: string;
+  magicLink?: AuthEmailFlowDeliveryOptions;
+  passwordReset?: AuthEmailFlowDeliveryOptions;
+  emailVerification?: AuthEmailFlowDeliveryOptions;
+}
+
 export interface AuthServiceOptions {
   passwordPolicyValidator?: PasswordPolicyValidator;
   auditSink?: AuthAuditSink;
   loginProtection?: LoginProtectionConfig;
   sessionStrategy?: AuthSessionStrategy;
+  email?: AuthEmailOptions;
 }
 
 export interface OAuthAuthorizationProviderConfig {


### PR DESCRIPTION
## Summary
- add optional auth email integration in `createAuthService` via `AuthServiceOptions.email`
- auto-deliver token emails for magic link, password reset, and email verification flows when provider is configured
- add per-flow opt-out and customization hooks (`enabled`, `from`, `to`, `render`)
- add focused auth service tests for delivery behavior and custom renderer/recipient overrides
- update auth/email package docs with usage and behavior notes

## Changes
- `packages/auth/src/types.ts`
  - add new email-related option types:
    - `AuthEmailFlow`, `AuthEmailDeliveryContext`, `AuthEmailDeliveryTemplate`
    - `AuthEmailFlowDeliveryOptions`, `AuthEmailOptions`
  - extend `AuthServiceOptions` with optional `email`
- `packages/auth/src/service.ts`
  - implement default auth email payload builder
  - implement per-flow option resolver + conditional delivery helper
  - wire delivery into:
    - `issueMagicLinkToken`
    - `issuePasswordResetToken`
    - `issueEmailVerificationToken`
- `packages/auth/src/service.test.ts`
  - add tests for:
    - auto delivery on magic link issuance
    - disabled flow opt-out
    - password reset custom renderer + recipient/from overrides
    - email verification custom recipient override
- `packages/auth/src/index.ts`
  - export new email option/context types
- `packages/auth/package.json`
  - add `@alesha-nov/email` workspace dependency
- docs updates:
  - `docs/packages/auth.md`
  - `docs/packages/email.md`

## Validation
- `bun run lint` ✅
- `bun run test` ✅
- `bun run --filter @alesha-nov/auth test --coverage --coverage-reporter=text` ✅
  - package coverage summary:
    - funcs: `99.70%`
    - lines: `99.59%`

Fixes #57