### PR TITLE
docs: align feature status + add Docker deploy baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+**/node_modules
+**/dist
+**/.output
+**/.vinxi
+**/.turbo
+**/.cache
+**/coverage
+**/.DS_Store
+*.log
+.env
+.env.*
+!.env.example
+.tmp*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.11 AS builder
+WORKDIR /app
+
+COPY . .
+
+RUN bun install --frozen-lockfile
+RUN bun run --filter web build
+
+FROM oven/bun:1.3.11 AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+COPY --from=builder /app/apps/web/dist ./apps/web/dist
+
+EXPOSE 3000
+
+CMD ["bun", "apps/web/dist/server/server.js"]

--- a/README.md
+++ b/README.md
@@ -2,52 +2,17 @@
 
 [![codecov](https://codecov.io/gh/JuniYadi/alesha-nov/graph/badge.svg?token=x0kbSnh7Ku)](https://codecov.io/gh/JuniYadi/alesha-nov)
 
-Bun workspace monorepo for:
+Bun workspace monorepo for auth-focused packages and a TanStack Start SSR demo app.
 
-- `@alesha-nov/config` — DB config + Bun SQL helpers + migration runner
-- `@alesha-nov/auth` — email/password auth + magic link auth + OAuth core
-- `@alesha-nov/email` — AWS SES and SMTP email providers
-- `@alesha-nov/auth-web` — HTTP auth route handlers + adapters for TanStack Start and Next.js
-- `@alesha-nov/auth-react` — React provider/hooks/guard for auth-web endpoints
+## Workspace layout
 
-## Target Product Auth Capabilities
+- `apps/web` — TanStack Start SSR app demonstrating auth flows
+- `packages/config` — DB + auth/email config resolvers, migration primitives
+- `packages/auth` — auth core service (email/password, magic link, OAuth, roles)
+- `packages/auth-web` — HTTP auth routes + TanStack/Next adapters
+- `packages/auth-react` — React provider/hooks/guard for auth-web endpoints
+- `packages/email` — SES/SMTP providers + templates/retry/rate-limit/status helpers
 
-Target state:
-- Login by email + password
-- Login by magic link (email)
-- Login by Google / GitHub
-
-Current readiness summary (verified from code):
-- Core primitives: **available** (`auth`, `auth-web`, `auth-react`)
-- Password reset flow: **available** in `auth`, `auth-web`, and `auth-react`
-- Integration hardening still **on-going**:
-  - OAuth redirect/callback flow (`auth-web`) — [#11](https://github.com/JuniYadi/alesha-nov/issues/11)
-  - OAuth client hooks (`auth-react`) — [#12](https://github.com/JuniYadi/alesha-nov/issues/12)
-  - Rate limiting / lockout (`auth`, `auth-web`) — [#24](https://github.com/JuniYadi/alesha-nov/issues/24), [#36](https://github.com/JuniYadi/alesha-nov/issues/36)
-  - Session refresh strategy (`auth-react`) — [#39](https://github.com/JuniYadi/alesha-nov/issues/39)
-
-## Package-Level Tracking
-
-Per-package tracking lives in:
-
-- `packages/config/README.md`
-- `packages/auth/README.md`
-- `packages/email/README.md`
-- `packages/auth-web/README.md`
-- `packages/auth-react/README.md`
-
-Docs mirror and consolidated matrix:
-- `docs/packages/`
-- `docs/packages/README.md`
-
-Open tracking issues (current):
-- config: [#21](https://github.com/JuniYadi/alesha-nov/issues/21), [#22](https://github.com/JuniYadi/alesha-nov/issues/22)
-- auth: [#23](https://github.com/JuniYadi/alesha-nov/issues/23), [#24](https://github.com/JuniYadi/alesha-nov/issues/24), [#25](https://github.com/JuniYadi/alesha-nov/issues/25), [#26](https://github.com/JuniYadi/alesha-nov/issues/26), [#27](https://github.com/JuniYadi/alesha-nov/issues/27)
-- email: [#28](https://github.com/JuniYadi/alesha-nov/issues/28), [#29](https://github.com/JuniYadi/alesha-nov/issues/29), [#30](https://github.com/JuniYadi/alesha-nov/issues/30), [#31](https://github.com/JuniYadi/alesha-nov/issues/31), [#32](https://github.com/JuniYadi/alesha-nov/issues/32), [#33](https://github.com/JuniYadi/alesha-nov/issues/33)
-- auth-web: [#11](https://github.com/JuniYadi/alesha-nov/issues/11), [#34](https://github.com/JuniYadi/alesha-nov/issues/34), [#35](https://github.com/JuniYadi/alesha-nov/issues/35), [#36](https://github.com/JuniYadi/alesha-nov/issues/36), [#37](https://github.com/JuniYadi/alesha-nov/issues/37)
-- auth-react: [#12](https://github.com/JuniYadi/alesha-nov/issues/12), [#38](https://github.com/JuniYadi/alesha-nov/issues/38), [#39](https://github.com/JuniYadi/alesha-nov/issues/39), [#40](https://github.com/JuniYadi/alesha-nov/issues/40)
-
-> Note: Issues #41 and #42 were created by delegated audit outside requested scope and then closed as not planned.
 ## Quick start
 
 ```bash
@@ -57,5 +22,72 @@ bun run build
 bun run typecheck
 bun run lint
 bun run test
-bun run test:coverage
 ```
+
+## TanStack SSR/API/auth wiring (current)
+
+Implemented in `apps/web`:
+
+- SSR app via `@tanstack/react-start` (`vite.config.ts` uses TanStack Start plugin)
+- Auth API route passthrough at `src/routes/auth/$.ts` to `getAuthHandler()`
+- Auth handler in `src/server/auth.ts` using `@alesha-nov/auth-web/tanstack`
+- Client auth provider in `src/routes/__root.tsx` using `AuthProvider`
+- Demo auth pages (`/signup`, `/login`) and protected page (`/dashboard`)
+
+Production hardening still recommended:
+
+- Add route-level SSR guards/loaders for protected pages (not client guard only)
+- Enforce strong `SESSION_SECRET` and production-safe cookie config
+- Add deployment pipeline (GitHub Actions + GHCR)
+
+## Package status snapshot
+
+Each package README tracks details. Highlights:
+
+- `auth`: core + security hardening pieces implemented
+- `auth-web`: OAuth authorize/callback, email verification, CORS, rate limiting, session revoke endpoints implemented
+- `auth-react`: OAuth login + magic-link hooks + session refresh + navigation adapter implemented
+- `config`: session/magic-link/email transport/OAuth env resolvers implemented
+- `email`: templates, retry/backoff, delivery status mapping, rate limiting, OTP/token helpers implemented
+
+## Docker deployment (first baseline)
+
+A root `Dockerfile` is provided for running `apps/web` SSR server.
+
+### Build image
+
+```bash
+docker build -t alesha-web:local .
+```
+
+### Run image
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e DB_TYPE=sqlite \
+  -e DATABASE_URL=':memory:' \
+  -e SESSION_SECRET='replace-with-strong-secret' \
+  alesha-web:local
+```
+
+Then open: `http://localhost:3000`
+
+### Required runtime env (minimum)
+
+- `DB_TYPE` (`mysql|postgresql|sqlite`)
+- `DATABASE_URL`
+- `SESSION_SECRET`
+
+For production, also set secure cookie/session and real DB/email/OAuth env values.
+
+## Release / publish
+
+Packages are released with Changesets:
+
+```bash
+bun run changeset
+# merge to main
+# release workflow publishes packages
+```
+
+Current workflows in `.github/workflows/` focus on lint/test/release. Container build/push pipeline is tracked separately.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,193 +1,67 @@
-Welcome to your new TanStack Start app! 
+# web (TanStack Start SSR demo)
 
-# Getting Started
+TanStack Start SSR app demonstrating how `@alesha-nov/*` packages are used together.
 
-To run this application:
+## What this app includes
+
+- TanStack Start SSR setup
+- Auth API passthrough route: `src/routes/auth/$.ts`
+- Auth handler factory: `src/server/auth.ts`
+- `AuthProvider` integration at root route
+- Demo pages:
+  - `/signup` (email/password signup)
+  - `/login` (email/password + magic-link demo)
+  - `/dashboard` (protected via `AuthGuard`)
+
+## Local run
+
+From repo root:
 
 ```bash
 bun install
-bun --bun run dev
+bun run --filter web dev
 ```
 
-# Building For Production
-
-To build this application for production:
+Or from `apps/web`:
 
 ```bash
-bun --bun run build
+bun install
+bun run dev
 ```
 
-## Testing
-
-This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:
+## Build and start
 
 ```bash
-bun --bun run test
+bun run --filter web build
+bun apps/web/dist/server/server.js
 ```
 
-## Styling
+App runs on port `3000` by default.
 
-This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.
+## Environment
 
-### Removing Tailwind CSS
+Minimum for meaningful auth run:
 
-If you prefer not to use Tailwind CSS:
+- `DB_TYPE` (`mysql|postgresql|sqlite`)
+- `DATABASE_URL`
+- `SESSION_SECRET`
 
-1. Remove the demo pages in `src/routes/demo/`
-2. Replace the Tailwind import in `src/styles.css` with your own styles
-3. Remove `tailwindcss()` from the plugins array in `vite.config.ts`
-4. Uninstall the packages: `bun install @tailwindcss/vite tailwindcss -D`
+Current server defaults are demo-friendly (e.g., fallback secret / insecure cookie). Harden before production.
 
+## Docker (from monorepo root)
 
-
-## Routing
-
-This project uses [TanStack Router](https://tanstack.com/router) with file-based routing. Routes are managed as files in `src/routes`.
-
-### Adding A Route
-
-To add a new route to your application just add a new file in the `./src/routes` directory.
-
-TanStack will automatically generate the content of the route file for you.
-
-Now that you have two routes you can use a `Link` component to navigate between them.
-
-### Adding Links
-
-To use SPA (Single Page Application) navigation you will need to import the `Link` component from `@tanstack/react-router`.
-
-```tsx
-import { Link } from "@tanstack/react-router";
+```bash
+docker build -t alesha-web:local .
+docker run --rm -p 3000:3000 \
+  -e DB_TYPE=sqlite \
+  -e DATABASE_URL=':memory:' \
+  -e SESSION_SECRET='replace-with-strong-secret' \
+  alesha-web:local
 ```
 
-Then anywhere in your JSX you can use it like so:
+## Notes for production hardening
 
-```tsx
-<Link to="/about">About</Link>
-```
-
-This will create a link that will navigate to the `/about` route.
-
-More information on the `Link` component can be found in the [Link documentation](https://tanstack.com/router/v1/docs/framework/react/api/router/linkComponent).
-
-### Using A Layout
-
-In the File Based Routing setup the layout is located in `src/routes/__root.tsx`. Anything you add to the root route will appear in all the routes. The route content will appear in the JSX where you render `{children}` in the `shellComponent`.
-
-Here is an example layout that includes a header:
-
-```tsx
-import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
-
-export const Route = createRootRoute({
-  head: () => ({
-    meta: [
-      { charSet: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { title: 'My App' },
-    ],
-  }),
-  shellComponent: ({ children }) => (
-    <html lang="en">
-      <head>
-        <HeadContent />
-      </head>
-      <body>
-        <header>
-          <nav>
-            <Link to="/">Home</Link>
-            <Link to="/about">About</Link>
-          </nav>
-        </header>
-        {children}
-        <Scripts />
-      </body>
-    </html>
-  ),
-})
-```
-
-More information on layouts can be found in the [Layouts documentation](https://tanstack.com/router/latest/docs/framework/react/guide/routing-concepts#layouts).
-
-## Server Functions
-
-TanStack Start provides server functions that allow you to write server-side code that seamlessly integrates with your client components.
-
-```tsx
-import { createServerFn } from '@tanstack/react-start'
-
-const getServerTime = createServerFn({
-  method: 'GET',
-}).handler(async () => {
-  return new Date().toISOString()
-})
-
-// Use in a component
-function MyComponent() {
-  const [time, setTime] = useState('')
-  
-  useEffect(() => {
-    getServerTime().then(setTime)
-  }, [])
-  
-  return <div>Server time: {time}</div>
-}
-```
-
-## API Routes
-
-You can create API routes by using the `server` property in your route definitions:
-
-```tsx
-import { createFileRoute } from '@tanstack/react-router'
-import { json } from '@tanstack/react-start'
-
-export const Route = createFileRoute('/api/hello')({
-  server: {
-    handlers: {
-      GET: () => json({ message: 'Hello, World!' }),
-    },
-  },
-})
-```
-
-## Data Fetching
-
-There are multiple ways to fetch data in your application. You can use TanStack Query to fetch data from a server. But you can also use the `loader` functionality built into TanStack Router to load the data for a route before it's rendered.
-
-For example:
-
-```tsx
-import { createFileRoute } from '@tanstack/react-router'
-
-export const Route = createFileRoute('/people')({
-  loader: async () => {
-    const response = await fetch('https://swapi.dev/api/people')
-    return response.json()
-  },
-  component: PeopleComponent,
-})
-
-function PeopleComponent() {
-  const data = Route.useLoaderData()
-  return (
-    <ul>
-      {data.results.map((person) => (
-        <li key={person.name}>{person.name}</li>
-      ))}
-    </ul>
-  )
-}
-```
-
-Loaders simplify your data fetching logic dramatically. Check out more information in the [Loader documentation](https://tanstack.com/router/latest/docs/framework/react/guide/data-loading#loader-parameters).
-
-# Demo files
-
-Files prefixed with `demo` can be safely deleted. They are there to provide a starting point for you to play around with the features you've installed.
-
-# Learn More
-
-You can learn more about all of the offerings from TanStack in the [TanStack documentation](https://tanstack.com).
-
-For TanStack Start specific documentation, visit [TanStack Start](https://tanstack.com/start).
+- Add SSR route-level auth guards/loaders for protected routes
+- Fail fast when `SESSION_SECRET` is missing
+- Use secure cookie settings in production
+- Replace demo magic-link UX with real email delivery flow

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -7,30 +7,25 @@ React client toolkit for authentication state, hooks, and route guarding.
 - `AuthProvider` to fetch `/session` + `/me`
 - `useAuth()` state hook
 - `useLogin()`, `useSignup()`, `useLogout()` mutation hooks
+- `usePasswordResetRequest()`, `useResetPassword()` hooks
+- `useMagicLinkRequest()`, `useMagicLinkVerify()` hooks
+- `useOAuthLogin()` hook for provider authorize redirect
 - `useAuthGuard()` and `AuthGuard` component
+- Session-expiry-aware refresh scheduling in provider
+- Navigation adapter support for route guards (`push`/`replace`)
 - Configurable `baseUrl` + `basePath`
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
 
 - Consume auth-web endpoints consistently
 - Keep client auth state synchronized with cookie session
-- Provide auth guard for protected routes
+- Provide route protection UX for protected views
 
-## Missing / On-going (Track Here)
+## Remaining / Follow-up
 
-- [ ] OAuth client hooks (`useOAuthLogin`, `useOAuthLink`) — [#12](https://github.com/JuniYadi/alesha-nov/issues/12)
-- [ ] Magic link hooks (`request`, `verify`) — [#38](https://github.com/JuniYadi/alesha-nov/issues/38)
-- [ ] Session expiry proactive refresh handling — [#39](https://github.com/JuniYadi/alesha-nov/issues/39)
-- [ ] Router-agnostic redirect adapter (instead of `window.location.href` only) — [#40](https://github.com/JuniYadi/alesha-nov/issues/40)
-
-## Already Implemented (was previously tracked as missing)
-
-- [x] Forgot/reset password hooks (`usePasswordResetRequest`, `useResetPassword`)
-- [x] Dedicated package docs under `docs/packages/auth-react.md`
+- OAuth account-linking hook (`useOAuthLink`) is not exposed yet
+- Recommended: add SSR-first guard patterns in app router (outside this package)
 
 ## Tracking Issues
 
-- [#12](https://github.com/JuniYadi/alesha-nov/issues/12) Add OAuth hooks for Google/GitHub login and linking (@alesha-nov/auth-react)
-- [#38](https://github.com/JuniYadi/alesha-nov/issues/38) Add magic-link hooks request/verify (@alesha-nov/auth-react)
-- [#39](https://github.com/JuniYadi/alesha-nov/issues/39) Add session-expiry-aware auto refresh/refetch (@alesha-nov/auth-react)
-- [#40](https://github.com/JuniYadi/alesha-nov/issues/40) Add pluggable navigation adapter for route guards (@alesha-nov/auth-react)
+Create/update issues for any new gaps discovered. Historical issues #12/#38/#39/#40 are closed.

--- a/packages/auth-web/README.md
+++ b/packages/auth-web/README.md
@@ -9,36 +9,32 @@ HTTP auth layer built on top of `@alesha-nov/auth` with cookie session handling 
 - Routes for:
   - signup/login/logout
   - session + me
+  - sessions revoke + revoke-all
   - magic-link request/verify
+  - password-reset request/reset
+  - email-verification request/verify
   - OAuth login/link (`google`/`github`)
+  - OAuth authorize + callback endpoints
   - linked accounts
   - roles update
 - Adapters:
   - `@alesha-nov/auth-web/next`
   - `@alesha-nov/auth-web/tanstack`
+- Configurable CORS support
+- Built-in/custom rate limiter support for public auth endpoints
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
 
 - Serve auth APIs consumed by frontend packages
 - Set/clear secure cookie session
 - Bridge OAuth identity data to auth service
+- Expose endpoint contracts usable by SSR/API frameworks
 
-## Missing / On-going (Track Here)
+## Remaining / Follow-up
 
-- [ ] OAuth redirect/callback flow endpoints (authorize + callback) — [#11](https://github.com/JuniYadi/alesha-nov/issues/11)
-- [ ] Email verification endpoints — [#34](https://github.com/JuniYadi/alesha-nov/issues/34)
-- [ ] CORS configuration options — [#35](https://github.com/JuniYadi/alesha-nov/issues/35)
-- [ ] Rate limiting for public auth endpoints — [#36](https://github.com/JuniYadi/alesha-nov/issues/36)
-- [ ] Session invalidation/revocation strategy beyond cookie clear — [#37](https://github.com/JuniYadi/alesha-nov/issues/37)
-
-## Already Implemented (was previously tracked as missing)
-
-- [x] Forgot/reset password API endpoints (`/password-reset/request`, `/password-reset/reset`)
+- Document production-grade OAuth provider exchange wiring examples
+- Improve persistence strategy for session revocation store if multi-instance deployment is required
 
 ## Tracking Issues
 
-- [#11](https://github.com/JuniYadi/alesha-nov/issues/11) Add OAuth authorize + callback endpoints (@alesha-nov/auth-web)
-- [#34](https://github.com/JuniYadi/alesha-nov/issues/34) Add email verification + resend endpoints (@alesha-nov/auth-web)
-- [#35](https://github.com/JuniYadi/alesha-nov/issues/35) Add configurable CORS policy support (@alesha-nov/auth-web)
-- [#36](https://github.com/JuniYadi/alesha-nov/issues/36) Add rate limiting for public auth endpoints (@alesha-nov/auth-web)
-- [#37](https://github.com/JuniYadi/alesha-nov/issues/37) Add server-side session revocation mechanism (@alesha-nov/auth-web)
+Create/update issues for newly discovered gaps. Historical issues #11/#34/#35/#36/#37 are closed.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,15 +1,22 @@
 # @alesha-nov/auth
 
-Core auth service for signup/login, magic link, and OAuth account login/linking.
+Core auth service for signup/login, magic link, OAuth account login/linking, and security controls.
 
 ## Implemented Features
 
 - Email/password signup + login
 - Password hashing and verification utilities
+- Password strength policy checks
+- Brute-force/rate-limit/lockout controls for login
 - Magic link issue + verify (hashed token storage)
+- Password reset issue + verify flows
+- Email verification issue + verify flows
 - OAuth login for `google` and `github`
 - OAuth account linking + linked accounts list
+- OAuth PKCE authorize request + callback validation helpers
 - Role assignment (`setUserRoles`, `getUserRoles`)
+- Session issuance + refresh contracts (strategy-based)
+- Audit events/hooks for auth lifecycle events
 - Auto migrations for auth tables
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
@@ -18,24 +25,13 @@ Core auth service for signup/login, magic link, and OAuth account login/linking.
 - `issueMagicLinkToken`, `verifyMagicLinkToken`
 - `loginWithOAuth(provider=google|github)`
 - Multi-role user model and retrieval
+- Session + refresh strategy integration
 
-## Missing / On-going (Track Here)
+## Remaining / Follow-up
 
-- [ ] Session/JWT issuance + refresh strategy contract — [#23](https://github.com/JuniYadi/alesha-nov/issues/23)
-- [ ] Brute-force/rate-limit/lockout protections — [#24](https://github.com/JuniYadi/alesha-nov/issues/24)
-- [ ] Password strength policy enforcement — [#25](https://github.com/JuniYadi/alesha-nov/issues/25)
-- [ ] OAuth PKCE/authorize-callback flow abstraction — [#27](https://github.com/JuniYadi/alesha-nov/issues/27)
-- [ ] Audit events/hooks (`LOGIN`, `LOGIN_FAIL`, `SIGNUP`, etc.) — [#26](https://github.com/JuniYadi/alesha-nov/issues/26)
-
-## Already Implemented (was previously tracked as missing)
-
-- [x] Forgot password + reset password flow
-- [x] Node compatibility for UUID generation (Bun v7 with Node fallback)
+- Add/extend persistence-backed session strategy examples for production
+- Expand docs with reference architecture for distributed deployments
 
 ## Tracking Issues
 
-- [#23](https://github.com/JuniYadi/alesha-nov/issues/23) Implement session/JWT issuance + refresh strategy contract (@alesha-nov/auth)
-- [#24](https://github.com/JuniYadi/alesha-nov/issues/24) Add brute-force protection and rate-limit/lockout (@alesha-nov/auth)
-- [#25](https://github.com/JuniYadi/alesha-nov/issues/25) Add password strength policy enforcement (@alesha-nov/auth)
-- [#26](https://github.com/JuniYadi/alesha-nov/issues/26) Add auth audit events/hooks interface (@alesha-nov/auth)
-- [#27](https://github.com/JuniYadi/alesha-nov/issues/27) Add OAuth PKCE authorize/callback abstraction (@alesha-nov/auth)
+Create/update issues for newly discovered gaps. Historical issues #23/#24/#25/#26/#27 are closed.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,6 +1,6 @@
 # @alesha-nov/config
 
-Database primitives for the monorepo: DB type resolution, SQL client creation, and migration runner.
+Database primitives and auth/email configuration resolvers for the monorepo.
 
 ## Implemented Features
 
@@ -9,26 +9,25 @@ Database primitives for the monorepo: DB type resolution, SQL client creation, a
 - `ensureMigrationsTable()` for `alesha_migrations`
 - `runMigrations()` idempotent migration execution
 - Exported types: `DBType`, `DBConfig`, `Migration`, `DatabaseClient`
+- Auth config types (`JWTConfig`, `SessionConfig`)
+- `resolveJWTSecret()`
+- `resolveSessionConfig()`
+- `resolveMagicLinkConfig()`
+- `resolveEmailTransportConfig()` (SES/SMTP with validation)
+- `resolveOAuthConfig()` (Google/GitHub)
+- `authMigrationsBundle` export for auth package consumption
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
 
 - Stable DB connection for all auth packages
 - Shared migration runner used by `@alesha-nov/auth`
-- Environment-driven DB type + URL
+- Environment-driven DB + auth/email transport resolution
 
-## Missing / On-going (Track Here)
+## Remaining / Follow-up
 
-- [ ] Session config env resolver (`resolveSessionConfig`) — [#21](https://github.com/JuniYadi/alesha-nov/issues/21)
-- [ ] Magic-link/email config resolver (TTL, sender, transport) — [#22](https://github.com/JuniYadi/alesha-nov/issues/22)
-
-## Already Implemented (was previously tracked as missing)
-
-- [x] Auth config types (`JWTConfig`, `SessionConfig`)
-- [x] OAuth config resolver (Google/GitHub client/secret/redirect)
-- [x] Canonical auth migration bundle export (`authMigrationsBundle`) consumed by `@alesha-nov/auth`
-- [x] Unit tests for auth config resolvers
+- Keep docs aligned when new env keys/resolvers are added
+- Expand examples for production env profiles
 
 ## Tracking Issues
 
-- [#21](https://github.com/JuniYadi/alesha-nov/issues/21) Add session config env resolver (@alesha-nov/config)
-- [#22](https://github.com/JuniYadi/alesha-nov/issues/22) Add magic-link/email configuration resolver (@alesha-nov/config)
+Create/update issues for newly discovered gaps. Historical issues #21/#22 are closed.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -1,6 +1,6 @@
 # @alesha-nov/email
 
-Provider-agnostic email delivery package (AWS SES + SMTP).
+Provider-agnostic email delivery package (AWS SES + SMTP) plus auth-focused helper utilities.
 
 ## Implemented Features
 
@@ -8,27 +8,28 @@ Provider-agnostic email delivery package (AWS SES + SMTP).
 - `createSmtpProvider()` using `nodemailer`
 - Shared `EmailProvider` interface with `send(message)`
 - Shared `EmailMessage` payload type (`from`, `to`, `subject`, `html?`, `text?`)
+- Auth template rendering utilities:
+  - `renderMagicLinkEmail`
+  - `renderVerifyEmailEmail`
+  - `renderResetPasswordEmail`
+  - `renderAuthTemplate`
+- Retry/backoff utilities (`withRetry`, backoff helpers)
+- Delivery status mapping/dispatch helpers (SES/SMTP)
+- Rate-limiting provider decorator (`withRateLimit`)
+- OTP/verification token generators + metadata helpers
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
 
 - Send magic-link emails reliably
 - Send verification and reset-password emails
 - Support transactional template payloads
+- Handle transient provider failures and throttling safely
 
-## Missing / On-going (Track Here)
+## Remaining / Follow-up
 
-- [ ] Email template system (magic-link, verify email, reset password) — [#28](https://github.com/JuniYadi/alesha-nov/issues/28)
-- [ ] Retry + backoff wrapper for transient failures — [#29](https://github.com/JuniYadi/alesha-nov/issues/29)
-- [ ] Delivery status tracking callbacks/webhooks — [#30](https://github.com/JuniYadi/alesha-nov/issues/30)
-- [ ] Rate limiting wrapper for provider throttling — [#31](https://github.com/JuniYadi/alesha-nov/issues/31)
-- [ ] OTP/verification token helper utilities — [#32](https://github.com/JuniYadi/alesha-nov/issues/32)
-- [ ] Stronger SMTP integration tests (send path + failure path) — [#33](https://github.com/JuniYadi/alesha-nov/issues/33)
+- Expand end-to-end provider integration coverage beyond current tests
+- Add cookbook examples for provider webhooks/feedback loops
 
 ## Tracking Issues
 
-- [#28](https://github.com/JuniYadi/alesha-nov/issues/28) Add auth-focused template renderer and typed payloads (@alesha-nov/email)
-- [#29](https://github.com/JuniYadi/alesha-nov/issues/29) Add retry/backoff email provider decorator (@alesha-nov/email)
-- [#30](https://github.com/JuniYadi/alesha-nov/issues/30) Add delivery status tracking API for bounces/complaints (@alesha-nov/email)
-- [#31](https://github.com/JuniYadi/alesha-nov/issues/31) Add provider rate-limiting wrapper (@alesha-nov/email)
-- [#32](https://github.com/JuniYadi/alesha-nov/issues/32) Add OTP/verification token helper utilities (@alesha-nov/email)
-- [#33](https://github.com/JuniYadi/alesha-nov/issues/33) Strengthen SMTP integration tests for send/failure paths (@alesha-nov/email)
+Create/update issues for newly discovered gaps. Historical issues #28/#29/#30/#31/#32/#33 are closed.


### PR DESCRIPTION
## Summary
This PR wraps up repository documentation drift and adds first-pass Docker deployment baseline for `apps/web`.

## What changed
- Added root `Dockerfile` for TanStack SSR app (`apps/web/dist/server/server.js`)
- Added root `.dockerignore`
- Updated root README:
  - workspace map
  - current TanStack SSR/API/auth integration status
  - Docker build/run instructions
  - minimum runtime env contract
- Updated `apps/web/README.md` with real run/build/start instructions and hardening notes
- Refreshed package README status to match current implementation:
  - `packages/auth/README.md`
  - `packages/auth-web/README.md`
  - `packages/auth-react/README.md`
  - `packages/config/README.md`
  - `packages/email/README.md`

## Validation
Executed after changes:
- `bun run lint` ✅
- `bun run test` ✅

Also verified Docker target app build/run path:
- `bun run --filter web build` ✅
- `bun apps/web/dist/server/server.js` and `curl http://127.0.0.1:3000` ✅

## Tracking issues
Created follow-up issues:
- #65 CI: build and publish apps/web Docker image to GHCR
- #66 TanStack SSR auth hardening for protected routes + prod session config
- #67 auth-react: add useOAuthLink hook for provider account linking
