### PR TITLE
fix(release): proper changeset workflow + access=public + version revert

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": true,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
   "ignore": []

--- a/.changeset/release-0-2-0.md
+++ b/.changeset/release-0-2-0.md
@@ -1,0 +1,9 @@
+---
+"@alesha-nov/config": minor
+"@alesha-nov/email": minor
+"@alesha-nov/auth": minor
+"@alesha-nov/auth-web": minor
+"@alesha-nov/auth-react": minor
+---
+
+chore: release all packages 0.1.0 → 0.2.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -128,6 +128,46 @@ jobs:
 
           echo "Affected packages: config=$config email=$email auth=$auth auth_web=$auth_web auth_react=$auth_react"
 
+      - name: Enforce changeset policy
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.sha }}"
+
+          # Check if any packages/* code changed but no .changeset/*.md exists in diff
+          has_package_changes=false
+          has_changeset=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              packages/*)
+                # Exclude package.json from this check since we handle that separately
+                if [[ "$file" != packages/*/package.json ]]; then
+                  has_package_changes=true
+                fi
+                ;;
+              .changeset/*.md) has_changeset=true ;;
+            esac
+          done < <(git diff --name-only "$base_sha" "$head_sha")
+
+          if [[ "$has_package_changes" == "true" && "$has_changeset" == "false" ]]; then
+            echo "ERROR: Package code changed but no .changeset/*.md file found in PR!"
+            exit 1
+          fi
+
+          # Check if any packages/*/package.json was manually edited
+          while IFS= read -r file; do
+            if [[ "$file" == packages/*/package.json ]]; then
+              echo "ERROR: Manual edit to $file detected. Package versions should only be changed via changesets!"
+              exit 1
+            fi
+          done < <(git diff --name-only "$base_sha" "$head_sha")
+
+          echo "✅ Changeset policy passed."
+
       - name: Lint @alesha-nov/config
         if: steps.affected.outputs.config == 'true'
         run: bun run --filter @alesha-nov/config lint

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alesha-node",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.1.0",
   "workspaces": [
     "packages/*",
     "apps/*"

--- a/packages/auth-react/package.json
+++ b/packages/auth-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth-react",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth-web/package.json
+++ b/packages/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth-web",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/auth",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/config",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alesha-nov/email",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

This PR fixes the changeset release workflow with the following changes:

### Version Revert (0.2.0 → 0.1.0)
- Reverted package versions in root  and all  from 0.2.0 back to 0.1.0

### .changeset/config.json
- Changed `access` from `restricted` to `public` to allow public npm registry publishing

### .github/workflows/pr-checks.yml
- Added **Enforce changeset policy** step as the first step in the lint job (after Detect affected packages)
- The step runs only on pull requests (`if: github.event_name == 'pull_request'`)
- Enforces two rules:
  1. If any packages/* code changes but no .changeset/*.md exists in the diff → exit 1
  2. If any packages/*/package.json was manually edited → exit 1

### .changeset/release-0-2-0.md
- Created changeset file for releasing all packages from 0.1.0 → 0.2.0

## Files Changed
- `.changeset/config.json` - access: restricted → public
- `.changeset/release-0-2-0.md` - new changeset file
- `.github/workflows/pr-checks.yml` - added Enforce changeset policy step
- `package.json` - version 0.2.0 → 0.1.0
- `packages/*/package.json` - version 0.2.0 → 0.1.0 (5 packages)