### PR TITLE
feat(auth-react): add useOAuthLink hook

### DIFF
--- a/.changeset/honest-masks-itch.md
+++ b/.changeset/honest-masks-itch.md
@@ -1,0 +1,7 @@
+---
+"@alesha-nov/auth-react": minor
+---
+
+Add `useOAuthLink` hook for linking authenticated users with OAuth provider accounts.
+
+This hook wraps `POST /oauth/:provider/link` with typed request/response models and exposes `{ link, data, loading, error }`, including auth-required handling for unauthenticated usage.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -266,29 +266,18 @@ jobs:
           fi
 
           if [[ "${run_auth_react}" == "true" ]]; then
-            # Run auth-react in package scope to avoid root-run module mock leakage.
-            # hooks.test.tsx mocks ./context at module scope; keep it in a separate Bun process
-            # so it cannot contaminate AuthProvider/AuthGuard/context tests.
+            # Run auth-react tests in a single coverage pass to avoid duplicate
+            # SF records in lcov that can confuse patch coverage calculation.
             pushd packages/auth-react >/dev/null
 
             bun test \
               --coverage \
               --coverage-reporter=lcov \
-              --coverage-dir ./coverage/non-hooks \
+              --coverage-dir ./coverage \
               --preload ./src/test-setup.ts \
               --max-concurrency 1 \
-              src/index.test.ts src/auth-guard.test.tsx src/context.test.tsx
+              src/index.test.ts src/auth-guard.test.tsx src/context.test.tsx src/hooks.test.tsx
 
-            bun test \
-              --coverage \
-              --coverage-reporter=lcov \
-              --coverage-dir ./coverage/hooks \
-              --preload ./src/test-setup.ts \
-              --max-concurrency 1 \
-              src/hooks.test.tsx
-
-            mkdir -p coverage
-            cat ./coverage/non-hooks/lcov.info ./coverage/hooks/lcov.info > ./coverage/lcov.info
             popd >/dev/null
 
             # Merge auth-react coverage into root lcov for Codecov upload.

--- a/packages/auth-react/CHANGELOG.md
+++ b/packages/auth-react/CHANGELOG.md
@@ -5,3 +5,7 @@
 ### Minor Changes
 
 - f1e8366: chore: release all packages 0.1.0 → 0.2.0
+
+### Patch
+
+- Added `useOAuthLink` hook for linking OAuth provider accounts from authenticated sessions.

--- a/packages/auth-react/README.md
+++ b/packages/auth-react/README.md
@@ -10,6 +10,7 @@ React client toolkit for authentication state, hooks, and route guarding.
 - `usePasswordResetRequest()`, `useResetPassword()` hooks
 - `useMagicLinkRequest()`, `useMagicLinkVerify()` hooks
 - `useOAuthLogin()` hook for provider authorize redirect
+- `useOAuthLink()` hook to link provider account credentials to authenticated users
 - `useAuthGuard()` and `AuthGuard` component
 - Session-expiry-aware refresh scheduling in provider
 - Navigation adapter support for route guards (`push`/`replace`)
@@ -23,8 +24,41 @@ React client toolkit for authentication state, hooks, and route guarding.
 
 ## Remaining / Follow-up
 
-- OAuth account-linking hook (`useOAuthLink`) is not exposed yet
 - Recommended: add SSR-first guard patterns in app router (outside this package)
+
+## Usage: useOAuthLink
+
+```ts
+import { useOAuthLink, useOAuthLogin } from "@alesha-nov/auth-react";
+import type { OAuthAccountLinkInput } from "@alesha-nov/auth-react";
+
+function LinkGoogleAccount() {
+  const { link, data, loading, error } = useOAuthLink();
+
+  const handleSubmit = async () => {
+    try {
+      const input: OAuthAccountLinkInput = {
+        providerAccountId: "google-oauth-account-id",
+        providerEmail: "user@gmail.com",
+      };
+      await link("google", input);
+    } catch {
+      // handle error
+    }
+  };
+
+  return {
+    loading,
+    error,
+    linkedProvider: data?.provider,
+    providerAccountId: data?.providerAccountId,
+  };
+}
+```
+
+Notes:
+- This hook requires an authenticated `AuthProvider` context.
+- The request targets `POST /oauth/:provider/link` and returns the created/linked account.
 
 ## Tracking Issues
 

--- a/packages/auth-react/src/hooks.test.tsx
+++ b/packages/auth-react/src/hooks.test.tsx
@@ -647,6 +647,14 @@ describe("useOAuthLink", () => {
     vi.clearAllMocks();
   });
 
+  test("initial state is reset", () => {
+    const { result } = renderHookWithAuth(() => useOAuthLink());
+
+    expect(result.current.data).toBe(null);
+    expect(result.current.error).toBe(null);
+    expect(result.current.loading).toBe(false);
+  });
+
   test("successful link posts payload and sets data", async () => {
     const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     const { result } = renderHookWithAuth(() => useOAuthLink({ basePath: "/auth" }));
@@ -693,6 +701,44 @@ describe("useOAuthLink", () => {
     expect(result.current.error).toBe("Authentication required to link OAuth accounts");
     expect(result.current.loading).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("uses fallback error message on non-error throw", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw "network disconnected";
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHookWithAuth(() => useOAuthLink({ basePath: "/auth" }));
+
+    await act(async () => {
+      try {
+        await result.current.link("google", { providerAccountId: "google-123" });
+      } catch {
+        // expected
+      }
+    });
+
+    expect(result.current.error).toBe("OAuth link failed");
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("uses baseUrl when building link endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { result } = renderHookWithAuth(() =>
+      useOAuthLink({ baseUrl: "https://api.example.com/", basePath: "/auth" }),
+    );
+
+    await act(async () => {
+      await result.current.link("google", { providerAccountId: "google-123", providerEmail: "user@gmail.com" });
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.example.com/auth/oauth/google/link",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
   });
 
   test("failed API request sets error", async () => {

--- a/packages/auth-react/src/hooks.test.tsx
+++ b/packages/auth-react/src/hooks.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach, vi } from "bun:test";
-import { act, renderHook, cleanup, waitFor } from "@testing-library/react";
+import { act, renderHook as renderHookBase, cleanup, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { AuthContext, type AuthContextValue } from "./context";
 import {
   useLogin,
   useSignup,
@@ -9,16 +11,10 @@ import {
   useMagicLinkRequest,
   useMagicLinkVerify,
   useOAuthLogin,
+  useOAuthLink,
   useAuthGuard,
 } from "./hooks";
-import type { PublicUser } from "./types";
-
-const useAuthMock = vi.fn();
-
-vi.mock("./context", () => ({
-  useAuth: useAuthMock,
-  AuthProvider: ({ children }: { children: unknown }) => children,
-}));
+import type { OAuthAccountLinkInput, PublicUser } from "./types";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -33,6 +29,27 @@ const mockUser: PublicUser = {
   createdAt: "2024-01-01T00:00:00.000Z",
   roles: ["admin"],
 };
+
+const makeAuthContext = (value?: Partial<AuthContextValue>): AuthContextValue => ({
+  status: value?.status ?? "unauthenticated",
+  user: value?.user ?? null,
+  session: value?.session ?? null,
+  refetch: value?.refetch ?? vi.fn().mockResolvedValue(undefined),
+});
+
+let authContextValue: AuthContextValue = makeAuthContext();
+
+function setAuthContext(value?: Partial<AuthContextValue>) {
+  authContextValue = makeAuthContext(value);
+}
+
+function AuthContextProviderWrapper({ children }: { children: ReactNode }) {
+  return <AuthContext.Provider value={authContextValue}>{children}</AuthContext.Provider>;
+}
+
+function renderHookWithAuth<T>(callback: () => T) {
+  return renderHookBase(callback, { wrapper: AuthContextProviderWrapper });
+}
 
 function setupFetch() {
   const fetchMock = vi.fn(async (url: string, options?: RequestInit) => {
@@ -79,6 +96,28 @@ function setupFetch() {
           headers: { "content-type": "application/json" },
         });
       }
+      if (url.includes("/oauth/google/link") || url.includes("/oauth/github/link")) {
+        const requestBody = options?.body
+          ? (JSON.parse(options.body as string) as Partial<OAuthAccountLinkInput>)
+          : ({} as Partial<OAuthAccountLinkInput>);
+        return new Response(
+          JSON.stringify({
+            account: {
+              id: "acct-1",
+              userId: "u-1",
+              provider: url.includes("/oauth/google/") ? "google" : "github",
+              providerAccountId: requestBody.providerAccountId ?? "provider-acc",
+              providerEmail: requestBody.providerEmail ?? null,
+              createdAt: "2024-01-01T00:00:00.000Z",
+              updatedAt: "2024-01-01T00:00:00.000Z",
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
     }
     return new Response(JSON.stringify({}), { status: 404 });
   });
@@ -99,7 +138,7 @@ describe("useLogin", () => {
 
   beforeEach(() => {
     fetchMock = setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -113,14 +152,14 @@ describe("useLogin", () => {
   });
 
   test("initial state has loading=false, error=null, data=null", () => {
-    const { result } = renderHook(() => useLogin());
+    const { result } = renderHookWithAuth(() => useLogin());
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(null);
     expect(result.current.data).toBe(null);
   });
 
   test("successful login sets data and calls refetch", async () => {
-    const { result } = renderHook(() => useLogin());
+    const { result } = renderHookWithAuth(() => useLogin());
 
     await act(async () => {
       await result.current.login({ email: "user@example.com", password: "password123" });
@@ -143,7 +182,7 @@ describe("useLogin", () => {
       return new Response(JSON.stringify({}), { status: 401 });
     });
 
-    const { result } = renderHook(() => useLogin());
+    const { result } = renderHookWithAuth(() => useLogin());
 
     await act(async () => {
       try {
@@ -171,7 +210,7 @@ describe("useLogin", () => {
       return new Response("", { status: 404 });
     });
 
-    const { result } = renderHook(() => useLogin());
+    const { result } = renderHookWithAuth(() => useLogin());
 
     await act(async () => {
       try {
@@ -192,7 +231,7 @@ describe("useSignup", () => {
 
   beforeEach(() => {
     fetchMock = setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -206,14 +245,14 @@ describe("useSignup", () => {
   });
 
   test("initial state", () => {
-    const { result } = renderHook(() => useSignup());
+    const { result } = renderHookWithAuth(() => useSignup());
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(null);
     expect(result.current.data).toBe(null);
   });
 
   test("successful signup sets data and calls refetch", async () => {
-    const { result } = renderHook(() => useSignup());
+    const { result } = renderHookWithAuth(() => useSignup());
 
     await act(async () => {
       await result.current.signup({ email: "new@example.com", password: "password123" });
@@ -237,7 +276,7 @@ describe("useSignup", () => {
       return new Response(null, { status: 401 });
     });
 
-    const { result } = renderHook(() => useSignup());
+    const { result } = renderHookWithAuth(() => useSignup());
 
     await act(async () => {
       try {
@@ -259,7 +298,7 @@ describe("useLogout", () => {
 
   beforeEach(() => {
     fetchMock = setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "authenticated",
       user: mockUser,
       session: { userId: "u-1", email: "user@example.com", roles: ["admin"], exp: 9999999999 },
@@ -273,13 +312,13 @@ describe("useLogout", () => {
   });
 
   test("initial state", () => {
-    const { result } = renderHook(() => useLogout());
+    const { result } = renderHookWithAuth(() => useLogout());
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe(null);
   });
 
   test("successful logout calls refetch", async () => {
-    const { result } = renderHook(() => useLogout());
+    const { result } = renderHookWithAuth(() => useLogout());
 
     await act(async () => {
       await result.current.logout();
@@ -301,7 +340,7 @@ describe("useLogout", () => {
       return new Response(null, { status: 401 });
     });
 
-    const { result } = renderHook(() => useLogout());
+    const { result } = renderHookWithAuth(() => useLogout());
 
     await act(async () => {
       try {
@@ -319,7 +358,7 @@ describe("useLogout", () => {
 describe("usePasswordResetRequest", () => {
   beforeEach(() => {
     setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -333,7 +372,7 @@ describe("usePasswordResetRequest", () => {
   });
 
   test("successful request sets sent=true", async () => {
-    const { result } = renderHook(() => usePasswordResetRequest());
+    const { result } = renderHookWithAuth(() => usePasswordResetRequest());
 
     await act(async () => {
       await result.current.request("user@example.com");
@@ -355,7 +394,7 @@ describe("usePasswordResetRequest", () => {
       return new Response(null, { status: 404 });
     }) as unknown as typeof fetch;
 
-    const { result } = renderHook(() => usePasswordResetRequest());
+    const { result } = renderHookWithAuth(() => usePasswordResetRequest());
 
     await act(async () => {
       try {
@@ -373,7 +412,7 @@ describe("usePasswordResetRequest", () => {
 describe("useResetPassword", () => {
   beforeEach(() => {
     setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -387,7 +426,7 @@ describe("useResetPassword", () => {
   });
 
   test("successful reset sets success=true", async () => {
-    const { result } = renderHook(() => useResetPassword());
+    const { result } = renderHookWithAuth(() => useResetPassword());
 
     await act(async () => {
       await result.current.reset("valid-reset-token", "new-pass-123");
@@ -409,7 +448,7 @@ describe("useResetPassword", () => {
       return new Response(null, { status: 404 });
     }) as unknown as typeof fetch;
 
-    const { result } = renderHook(() => useResetPassword());
+    const { result } = renderHookWithAuth(() => useResetPassword());
 
     await act(async () => {
       try {
@@ -427,7 +466,7 @@ describe("useResetPassword", () => {
 describe("useMagicLinkRequest", () => {
   beforeEach(() => {
     setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -442,7 +481,7 @@ describe("useMagicLinkRequest", () => {
 
   test("successful request sets sent=true and posts payload", async () => {
     const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
-    const { result } = renderHook(() => useMagicLinkRequest({ basePath: "/auth" }));
+    const { result } = renderHookWithAuth(() => useMagicLinkRequest({ basePath: "/auth" }));
 
     await act(async () => {
       await result.current.request({ email: "user@example.com", ttlSeconds: 120 });
@@ -465,7 +504,7 @@ describe("useMagicLinkRequest", () => {
       return new Response(JSON.stringify({}), { status: 404 });
     }) as unknown as typeof fetch;
 
-    const { result } = renderHook(() => useMagicLinkRequest());
+    const { result } = renderHookWithAuth(() => useMagicLinkRequest());
 
     await act(async () => {
       try {
@@ -485,7 +524,7 @@ describe("useMagicLinkVerify", () => {
 
   beforeEach(() => {
     setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -499,7 +538,7 @@ describe("useMagicLinkVerify", () => {
   });
 
   test("successful verify sets data and calls refetch", async () => {
-    const { result } = renderHook(() => useMagicLinkVerify());
+    const { result } = renderHookWithAuth(() => useMagicLinkVerify());
 
     await act(async () => {
       await result.current.verify({ token: "magic-token" });
@@ -522,7 +561,7 @@ describe("useMagicLinkVerify", () => {
       return new Response(JSON.stringify({}), { status: 404 });
     }) as unknown as typeof fetch;
 
-    const { result } = renderHook(() => useMagicLinkVerify());
+    const { result } = renderHookWithAuth(() => useMagicLinkVerify());
 
     await act(async () => {
       try {
@@ -541,7 +580,7 @@ describe("useMagicLinkVerify", () => {
 describe("useOAuthLogin", () => {
   beforeEach(() => {
     setupFetch();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -557,7 +596,7 @@ describe("useOAuthLogin", () => {
   test("redirects browser to oauth authorize endpoint", () => {
     const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
 
-    const { result } = renderHook(() => useOAuthLogin({ basePath: "/auth" }));
+    const { result } = renderHookWithAuth(() => useOAuthLogin({ basePath: "/auth" }));
 
     act(() => {
       result.current.login("google");
@@ -575,7 +614,7 @@ describe("useOAuthLogin", () => {
       throw new Error("redirect failed");
     });
 
-    const { result } = renderHook(() => useOAuthLogin({ basePath: "/auth" }));
+    const { result } = renderHookWithAuth(() => useOAuthLogin({ basePath: "/auth" }));
 
     act(() => {
       try {
@@ -592,6 +631,97 @@ describe("useOAuthLogin", () => {
 
 });
 
+describe("useOAuthLink", () => {
+  beforeEach(() => {
+    setupFetch();
+    setAuthContext({
+      status: "authenticated",
+      user: mockUser,
+      session: { userId: "u-1", email: "user@example.com", roles: ["admin"], exp: 9999999999 },
+      refetch: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test("successful link posts payload and sets data", async () => {
+    const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const { result } = renderHookWithAuth(() => useOAuthLink({ basePath: "/auth" }));
+
+    await act(async () => {
+      await result.current.link("google", { providerAccountId: "google-123", providerEmail: "user@gmail.com" });
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith("/auth/oauth/google/link", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ providerAccountId: "google-123", providerEmail: "user@gmail.com" }),
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+    }));
+    expect(result.current.data).toMatchObject({
+      id: "acct-1",
+      provider: "google",
+      providerAccountId: "google-123",
+      providerEmail: "user@gmail.com",
+    });
+    expect(result.current.error).toBe(null);
+    expect(result.current.loading).toBe(false);
+  });
+
+  test("throws when not authenticated without calling backend", async () => {
+    const fetchSpy = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    setAuthContext({
+      status: "unauthenticated",
+      user: null,
+      session: null,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHookWithAuth(() => useOAuthLink());
+
+    await act(async () => {
+      try {
+        await result.current.link("github", { providerAccountId: "github-123" });
+      } catch {
+        // expected
+      }
+    });
+
+    expect(result.current.error).toBe("Authentication required to link OAuth accounts");
+    expect(result.current.loading).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("failed API request sets error", async () => {
+    globalThis.fetch = vi.fn(async (url: string, options?: RequestInit) => {
+      if (options?.method === "POST" && (url.includes("/oauth/google/link") || url.includes("/oauth/github/link"))) {
+        return new Response(JSON.stringify({ error: "Provider account already linked" }), {
+          status: 409,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHookWithAuth(() => useOAuthLink());
+
+    await act(async () => {
+      try {
+        await result.current.link("google", { providerAccountId: "google-123" });
+      } catch {
+        // expected
+      }
+    });
+
+    expect(result.current.error).toBe("Provider account already linked");
+    expect(result.current.data).toBe(null);
+    expect(result.current.loading).toBe(false);
+  });
+});
+
 describe("useAuthGuard", () => {
   beforeEach(() => {
     setupFetch();
@@ -604,14 +734,14 @@ describe("useAuthGuard", () => {
 
   test("uses navigation adapter push for unauthenticated redirects", async () => {
     const push = vi.fn();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    renderHook(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { push } }));
+    renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { push } }));
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith("/login");
@@ -620,14 +750,14 @@ describe("useAuthGuard", () => {
 
   test("uses navigation adapter replace when requested", async () => {
     const replace = vi.fn();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    renderHook(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { replace }, replace: true }));
+    renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { replace }, replace: true }));
 
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/login");
@@ -635,7 +765,7 @@ describe("useAuthGuard", () => {
   });
 
   test("falls back to window.location.assign when no adapter provided", async () => {
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
@@ -644,7 +774,7 @@ describe("useAuthGuard", () => {
 
     const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
 
-    renderHook(() => useAuthGuard({ redirectTo: "/login" }));
+    renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login" }));
 
     await waitFor(() => {
       expect(assignSpy).toHaveBeenCalledWith("/login");
@@ -655,14 +785,14 @@ describe("useAuthGuard", () => {
 
   test("uses adapter replace as fallback when push is missing", async () => {
     const replace = vi.fn();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    renderHook(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { replace } }));
+    renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { replace } }));
 
     await waitFor(() => {
       expect(replace).toHaveBeenCalledWith("/login");
@@ -671,14 +801,14 @@ describe("useAuthGuard", () => {
 
   test("prefers adapter push when replace flag is true but replace fn is missing", async () => {
     const push = vi.fn();
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    renderHook(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { push }, replace: true }));
+    renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login", navigationAdapter: { push }, replace: true }));
 
     await waitFor(() => {
       expect(push).toHaveBeenCalledWith("/login");
@@ -687,14 +817,14 @@ describe("useAuthGuard", () => {
 
   test("uses custom baseUrl for oauth redirect", () => {
     const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "unauthenticated",
       user: null,
       session: null,
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    const { result } = renderHook(() => useOAuthLogin({ baseUrl: "https://api.example.com/", basePath: "/auth" }));
+    const { result } = renderHookWithAuth(() => useOAuthLogin({ baseUrl: "https://api.example.com/", basePath: "/auth" }));
 
     act(() => {
       result.current.login("github");
@@ -705,14 +835,14 @@ describe("useAuthGuard", () => {
   });
 
   test("returns loading/authenticated flags from context status", () => {
-    useAuthMock.mockReturnValue({
+    setAuthContext({
       status: "authenticated",
       user: mockUser,
       session: { userId: "u-1", email: "user@example.com", roles: ["admin"], exp: 9999999999 },
       refetch: vi.fn().mockResolvedValue(undefined),
     });
 
-    const { result } = renderHook(() => useAuthGuard({ redirectTo: "/login" }));
+    const { result } = renderHookWithAuth(() => useAuthGuard({ redirectTo: "/login" }));
     expect(result.current.isLoading).toBe(false);
     expect(result.current.isAuthenticated).toBe(true);
   });

--- a/packages/auth-react/src/hooks.ts
+++ b/packages/auth-react/src/hooks.ts
@@ -7,6 +7,8 @@ import type {
   SignupInput,
   PublicUser,
   OAuthProvider,
+  OAuthAccountLinkInput,
+  OAuthAccountLink,
   MagicLinkRequestInput,
   MagicLinkVerifyInput,
   UseAuthGuardOptions,
@@ -256,6 +258,38 @@ export function useOAuthLogin(config: AuthApiConfig = {}) {
   );
 
   return { login, loading, error };
+}
+
+export function useOAuthLink(config: AuthApiConfig = {}) {
+  const auth = useAuth();
+  const [data, setData] = useState<OAuthAccountLink | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const link = useCallback(
+    async (provider: OAuthProvider, input: OAuthAccountLinkInput) => {
+      setLoading(true);
+      setError(null);
+      try {
+        if (auth.status !== "authenticated") {
+          throw new Error("Authentication required to link OAuth accounts");
+        }
+
+        const res = await postJson<{ account: OAuthAccountLink }>(`/oauth/${provider}/link`, input, config);
+        setData(res.account);
+        return res.account;
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "OAuth link failed";
+        setError(msg);
+        throw e;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [auth, config],
+  );
+
+  return { link, data, error, loading };
 }
 
 export function useAuthGuard(options: UseAuthGuardOptions = {}) {

--- a/packages/auth-react/src/index.test.ts
+++ b/packages/auth-react/src/index.test.ts
@@ -20,6 +20,7 @@ describe("auth-react exports", () => {
       useMagicLinkRequest,
       useMagicLinkVerify,
       useOAuthLogin,
+      useOAuthLink,
       useAuthGuard,
     } = await import("./hooks");
 
@@ -31,6 +32,7 @@ describe("auth-react exports", () => {
     expect(useMagicLinkRequest).toBeDefined();
     expect(useMagicLinkVerify).toBeDefined();
     expect(useOAuthLogin).toBeDefined();
+    expect(useOAuthLink).toBeDefined();
     expect(useAuthGuard).toBeDefined();
   });
 
@@ -51,6 +53,7 @@ describe("auth-react exports", () => {
     expect(mod.useResetPassword).toBeDefined();
     expect(mod.useMagicLinkRequest).toBeDefined();
     expect(mod.useMagicLinkVerify).toBeDefined();
+    expect(mod.useOAuthLink).toBeDefined();
     expect(mod.useAuthGuard).toBeDefined();
     expect(mod.AuthGuard).toBeDefined();
   });

--- a/packages/auth-react/src/index.ts
+++ b/packages/auth-react/src/index.ts
@@ -10,6 +10,7 @@ export {
   useMagicLinkRequest,
   useMagicLinkVerify,
   useOAuthLogin,
+  useOAuthLink,
   useAuthGuard,
 } from "./hooks";
 
@@ -24,5 +25,7 @@ export type {
   AuthGuardNavigationAdapter,
   MagicLinkRequestInput,
   MagicLinkVerifyInput,
+  OAuthAccountLinkInput,
+  OAuthAccountLink,
   UseAuthGuardOptions,
 } from "./types";

--- a/packages/auth-react/src/types.ts
+++ b/packages/auth-react/src/types.ts
@@ -61,6 +61,21 @@ export interface MagicLinkVerifyInput {
   token: string;
 }
 
+export interface OAuthAccountLinkInput {
+  providerAccountId: string;
+  providerEmail?: string;
+}
+
+export interface OAuthAccountLink {
+  id: string;
+  userId: string;
+  provider: OAuthProvider;
+  providerAccountId: string;
+  providerEmail: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface UseAuthGuardOptions {
   redirectTo?: string;
   navigationAdapter?: AuthGuardNavigationAdapter;


### PR DESCRIPTION
## Summary\n- Add `useOAuthLink` to `@alesha-nov/auth-react` for linking OAuth provider accounts against an authenticated session.\n- Hook posts to `POST /oauth/{provider}/link` and returns `{ link, data, loading, error }`.\n- Add auth-required guard inside hook (throws/sets error when unauthenticated).\n- Export new hook/types in package barrel and update docs.\n- Add tests for success/failure and auth-required behavior.\n\n## Test Plan\n- `bun test` in `packages/auth-react`\n- `bun run lint` in `packages/auth-react`\n\n## Related Issue\n- https://github.com/JuniYadi/alesha-nov/issues/67