### PR TITLE
fix(docker): optimize monorepo build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,34 @@
 FROM oven/bun:1.3.11 AS builder
 WORKDIR /app
 
-COPY . .
+COPY package.json bun.lock ./
+COPY apps/web/package.json apps/web/tsconfig.json apps/web/vite.config.ts ./apps/web/
+COPY packages/config/package.json packages/config/tsconfig.json ./packages/config/
+COPY packages/email/package.json packages/email/tsconfig.json ./packages/email/
+COPY packages/auth/package.json packages/auth/tsconfig.json ./packages/auth/
+COPY packages/auth-web/package.json packages/auth-web/tsconfig.json ./packages/auth-web/
+COPY packages/auth-react/package.json packages/auth-react/tsconfig.json ./packages/auth-react/
 
 RUN bun install --frozen-lockfile
-RUN bun run --filter web build
+COPY . .
+RUN bun run build
 
 FROM oven/bun:1.3.11 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3000
+
+COPY package.json bun.lock ./
+COPY apps/web/package.json ./apps/web/
+COPY apps/web/tsconfig.json ./apps/web/
+COPY packages/config/package.json ./packages/config/
+COPY packages/email/package.json ./packages/email/
+COPY packages/auth/package.json ./packages/auth/
+COPY packages/auth-web/package.json ./packages/auth-web/
+COPY packages/auth-react/package.json ./packages/auth-react/
+
+RUN bun install --frozen-lockfile --production
 
 COPY --from=builder /app/apps/web/dist ./apps/web/dist
 


### PR DESCRIPTION
## Summary
- update Dockerfile to copy workspace manifests before source to improve build-layer caching
- install dependencies in runner stage with production lockfile before copying app artifacts
- run root build command so monorepo package dependencies are resolved correctly for web output