### PR TITLE
Fix Dockerfile workspace package mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,8 @@ FROM oven/bun:1.3.11 AS builder
 WORKDIR /app
 
 COPY package.json bun.lock ./
-COPY apps/web/package.json apps/web/tsconfig.json apps/web/vite.config.ts ./apps/web/
-COPY packages/config/package.json packages/config/tsconfig.json ./packages/config/
-COPY packages/email/package.json packages/email/tsconfig.json ./packages/email/
-COPY packages/auth/package.json packages/auth/tsconfig.json ./packages/auth/
-COPY packages/auth-web/package.json packages/auth-web/tsconfig.json ./packages/auth-web/
-COPY packages/auth-react/package.json packages/auth-react/tsconfig.json ./packages/auth-react/
+COPY apps ./apps
+COPY packages ./packages
 
 RUN bun install --frozen-lockfile
 COPY . .
@@ -22,13 +18,8 @@ ENV NODE_ENV=production
 ENV PORT=3000
 
 COPY package.json bun.lock ./
-COPY apps/web/package.json ./apps/web/
-COPY apps/web/tsconfig.json ./apps/web/
-COPY packages/config/package.json ./packages/config/
-COPY packages/email/package.json ./packages/email/
-COPY packages/auth/package.json ./packages/auth/
-COPY packages/auth-web/package.json ./packages/auth-web/
-COPY packages/auth-react/package.json ./packages/auth-react/
+COPY apps ./apps
+COPY packages ./packages
 
 RUN bun install --frozen-lockfile --production
 


### PR DESCRIPTION
## Summary
- Replace hardcoded package-specific COPY lines in Dockerfile with whole workspace directories for apps and packages
- Ensure Bun workspace install can discover newly added packages like @alesha-nov/db during image build
- Prevent future build failures from missing workspace manifests without touching Dockerfile each time

## Why
Bun resolves workspace dependencies by scanning workspace folders, and the previous Dockerfile only copied a fixed subset of package manifests, so new packages were unavailable during bun install v1.3.12 (700fc117)

Checked 628 installs across 693 packages (no changes) [130.00ms].

## Testing
- Build not run in this change; verified via static Dockerfile inspection and related workspace error context