### PR TITLE
Fix Bun DB boundary for auth route

### DIFF
--- a/.changeset/fresh-pears-smile.md
+++ b/.changeset/fresh-pears-smile.md
@@ -1,0 +1,5 @@
+---
+"@alesha-nov/db": patch
+---
+
+Avoid exposing Bun SQL internals in client-capable code paths by resolving Bun DB access at runtime and keeping the auth route handler inside a server-only boundary.

--- a/apps/web/src/routes/auth/$.ts
+++ b/apps/web/src/routes/auth/$.ts
@@ -1,47 +1,51 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { getAuthHandler } from '../../server/auth'
+
+async function getAuthRouteHandler() {
+  const { getAuthHandler } = await import('../../server/auth')
+  return getAuthHandler()
+}
 
 export const Route = createFileRoute('/auth/$')({
   server: {
     handlers: {
       GET: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       POST: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       PUT: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       DELETE: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       PATCH: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       HEAD: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response
       },
       OPTIONS: async ({ request, next }) => {
-        const handler = await getAuthHandler()
+        const handler = await getAuthRouteHandler()
         const response = await handler(request)
         if (response.status === 404) return next()
         return response

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -1,3 +1,5 @@
+import '@tanstack/react-start/server-only'
+
 import { createAuthService } from '@alesha-nov/auth'
 import { getSessionFromRequest, type AuthSession } from '@alesha-nov/auth-web'
 import { createTanstackAuthHandler } from '@alesha-nov/auth-web/tanstack'

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,18 +12,25 @@ const config = defineConfig({
     devtools(),
     tsconfigPaths({ projects: ['./tsconfig.json'] }),
     tailwindcss(),
-    tanstackStart(),
+    tanstackStart({
+      importProtection: {
+        client: {
+          // @alesha-nov/db is Bun-only and should never be imported on client.
+          specifiers: ['@alesha-nov/db'],
+        },
+      },
+    }),
     viteReact(),
   ],
-  ssr: {
-    // @alesha-nov/db uses Bun's SQL class — externalize so it only
-    // runs in Bun Node.js runtime, not bundled into SSR output.
-    external: ['bun'],
-  },
   build: {
     rollupOptions: {
       external: ['bun'],
     },
+  },
+  ssr: {
+    // Vite will leave Bun built-ins external, so they fail fast only if
+    // actually loaded by Bun runtime code.
+    external: ['bun'],
   },
 })
 

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -1,5 +1,60 @@
 import { describe, expect, test } from "bun:test";
-import { resolveDBType } from "./index";
+import { createDatabaseClient, resolveDBType } from "./index";
+
+const BunRuntime = globalThis as {
+  Bun?: {
+    sql?: unknown;
+  };
+};
+
+function withBunSql<T>(nextSql: unknown, run: () => T): T {
+  const bun = BunRuntime.Bun;
+  const previousSql = bun?.sql;
+
+  if (!bun) {
+    throw new Error("Bun runtime is not available in this test environment.");
+  }
+
+  bun.sql = nextSql;
+  try {
+    return run();
+  } finally {
+    bun.sql = previousSql;
+  }
+}
+
+describe("createDatabaseClient", () => {
+  test("throws with clear error when Bun.sql is missing", () => {
+    expect(() => {
+      withBunSql(undefined, () => createDatabaseClient({ type: "sqlite", url: ":memory:" }));
+    }).toThrow(
+      "Bun SQL runtime is not available. Run the app in a Bun runtime to use @alesha-nov/db."
+    );
+  });
+
+  test("throws with clear error when Bun.sql is not callable", () => {
+    expect(() => {
+      withBunSql({}, () => createDatabaseClient({ type: "sqlite", url: ":memory:" }));
+    }).toThrow("Bun SQL runtime is not callable. Check the Bun environment version.");
+  });
+
+  test("returns configured client when Bun.sql is valid", () => {
+    const fakeSql = function (_url: string, _options?: { max?: number }) {
+      return {
+        __url: _url,
+        __options: _options,
+      } as unknown as ReturnType<typeof createDatabaseClient>["sql"];
+    };
+
+    const client = withBunSql(fakeSql, () =>
+      createDatabaseClient({ type: "sqlite", url: ":memory:", maxConnections: 12 })
+    );
+
+    expect(client.config).toEqual({ type: "sqlite", url: ":memory:", maxConnections: 12 });
+    expect((client.sql as { __url?: string; __options?: { max?: number } }).__url).toBe(":memory:");
+    expect((client.sql as { __options?: { max?: number } }).__options?.max).toBe(12);
+  });
+});
 
 describe("resolveDBType", () => {
   test("returns mysql", () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-import { SQL } from "bun";
+import type { SQL } from "bun";
 
 export type DBType = "mysql" | "postgresql" | "sqlite";
 
@@ -35,9 +35,30 @@ export function resolveDBType(input?: string): DBType {
 }
 
 export function createDatabaseClient(config: DBConfig): DatabaseClient {
-  const sql = new SQL(config.url, {
-    max: config.maxConnections ?? 10,
-  });
+  const BunRuntime = globalThis as {
+    Bun?: {
+      sql?: unknown;
+    };
+  };
+
+  const SQLCtor = BunRuntime.Bun?.sql;
+
+  if (!SQLCtor) {
+    throw new Error(
+      "Bun SQL runtime is not available. Run the app in a Bun runtime to use @alesha-nov/db."
+    );
+  }
+
+  if (typeof SQLCtor !== "function") {
+    throw new Error("Bun SQL runtime is not callable. Check the Bun environment version.");
+  }
+
+  const sql = new (SQLCtor as new (url: string, options?: { max?: number }) => SQL)(
+    config.url,
+    {
+      max: config.maxConnections ?? 10,
+    }
+  );
 
   return { sql, config };
 }


### PR DESCRIPTION
## Summary\n- Enforce server-only routing boundary for `/auth` handler loading to avoid client leakage.\n- Mark auth server module with TanStack Start `server-only` import.\n- Add TanStack import protection for Bun-only package specifier `@alesha-nov/db` in Vite config.\n- Remove static Bun import from `@alesha-nov/db` package API by resolving `Bun.sql` via runtime check on `globalThis`.\n\n## Why\nThe previous implementation could still surface Bun-only DB module behavior in dev routing paths. These changes keep auth execution in server context and fail with explicit runtime errors when Bun SQL is not available, while preventing accidental client imports.\n\n## Validation\n- `bun run --filter @alesha-nov/db typecheck`\n- `bun run --filter web typecheck`\n- `bun run --filter @alesha-nov/db build`\n- `bun run web build`\n