### PR TITLE
Add web env example template and docs

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,9 @@
 DB_TYPE=sqlite
 DATABASE_URL=:memory:
+# Generate locally:
+# openssl rand -hex 32
+# or
+# openssl rand -base64 48
 SESSION_SECRET=replace-with-long-random-string
 AUTH_SECURE_COOKIE=false
 NODE_ENV=development

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,5 @@
+DB_TYPE=sqlite
+DATABASE_URL=:memory:
+SESSION_SECRET=replace-with-long-random-string
+AUTH_SECURE_COOKIE=false
+NODE_ENV=development

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -4,6 +4,8 @@ dist
 dist-ssr
 *.local
 .env
+.env.example
+!.env.example
 .nitro
 .tanstack
 .wrangler

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -40,13 +40,24 @@ App runs on port `3000` by default.
 
 ## Environment
 
+Use `.env.example` as a base:
+
+```bash
+cd apps/web
+cp .env.example .env
+```
+
 Minimum for meaningful auth run:
 
 - `DB_TYPE` (`mysql|postgresql|sqlite`)
 - `DATABASE_URL`
 - `SESSION_SECRET`
+- `AUTH_SECURE_COOKIE` (optional, defaults to `true` in production)
 
-Current server defaults are demo-friendly (e.g., fallback secret / insecure cookie). Harden before production.
+Current server defaults are demo-friendly (fallback secret / insecure cookie).
+`apps/web/.env.example` contains a safe local starter profile.
+
+For production, replace insecure defaults and set `NODE_ENV=production`.
 
 ## Docker (from monorepo root)
 


### PR DESCRIPTION
## Summary
- add apps/web/.env.example with required auth/database variables
- document local setup with .env.example copy flow in README
- update apps/web/.gitignore to allow committing .env.example while keeping .env files ignored

## Why
This makes local configuration explicit and avoids accidental check-in of real environment secrets while preserving discoverable defaults for development.
