### PR TITLE
Use bunx for Vite scripts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,9 +7,9 @@
     "#/*": "./src/*"
   },
   "scripts": {
-    "dev": "vite dev --port 3000",
-    "build": "vite build",
-    "preview": "vite preview",
+    "dev": "bunx --bun vite dev --port 3000",
+    "build": "bunx --bun vite build",
+    "preview": "bunx --bun vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Update web app Vite scripts (dev, build, preview) to run via bunx --bun vite.
- Keep command behavior and flags intact while using Bun runtime.

## Why
- Inject Bun execution path for Vite commands per runtime preference.