### PR TITLE
feat: add E2E testing with Playwright

### DIFF
--- a/apps/web/E2E-TESTING.md
+++ b/apps/web/E2E-TESTING.md
@@ -1,0 +1,132 @@
+# E2E Testing Checklist
+
+## Testing URL: http://172.25.131.143:3000/
+
+---
+
+## Feature Checklist
+
+### 1. Home Page (`/`)
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 1.1 | Page loads successfully | Page renders without errors | ✅ |
+| 1.2 | Auth status displays correctly | Shows `unauthenticated` when logged out | ✅ |
+| 1.3 | Navigation links visible | Home, Signup, Login, Dashboard links present | ✅ |
+| 1.4 | Click "Go to Signup" navigates to `/signup` | URL changes to `/signup` | ✅ |
+| 1.5 | Click "Go to Login" navigates to `/login` | URL changes to `/login` | ✅ |
+| 1.6 | Click "Open Dashboard" when logged out redirects | Redirects to `/login` | ✅ |
+
+### 2. Signup Page (`/signup`)
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 2.1 | Page loads with signup form | Name, Email, Password fields + Submit button | ✅ |
+| 2.2 | Submit empty form | HTML5 validation triggers | ✅ |
+| 2.3 | Submit valid signup form | Account created, success message | ✅ |
+| 2.4 | Signup then login flow | Full auth flow works end-to-end | ✅ |
+
+### 3. Login Page (`/login`)
+
+#### 3.1 Email/Password Login
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 3.1.1 | Page loads with login form | Email + Password fields + Login button | ✅ |
+| 3.1.2 | Login with invalid credentials | Error message displayed | ✅ |
+
+#### 3.2 Magic Link Login
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 3.2.1 | Request magic link token | Button clickable, response shown | ✅ |
+
+### 4. Dashboard Page (`/dashboard`) - Protected Route
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 4.1 | Access without login | Redirects to `/login` | ✅ |
+| 4.2 | Access while logged in | Shows user email and roles | ✅ |
+| 4.3 | Logout button | Clears session, redirects to `/login` | ✅ |
+
+### 5. Theme Toggle
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 5.1 | Default theme is "Auto" | Shows "Auto" button text | ✅ |
+| 5.2 | Cycles: Auto → Light → Dark → Auto | Theme changes accordingly | ✅ |
+| 5.3 | Theme persists on page reload | Selected theme maintained | ✅ |
+| 5.4 | Light mode applies `light` class | CSS class `light` on html element | ✅ |
+| 5.5 | Dark mode applies `dark` class | CSS class `dark` on html element | ✅ |
+
+### 6. Navigation / Header
+
+| # | Test Case | Expected Result | Status |
+|---|-----------|-----------------|--------|
+| 6.1 | Header sticky at top | Header stays visible on scroll | ✅ |
+| 6.2 | Nav links navigate correctly | Home, Signup, Login links work | ✅ |
+| 6.3 | Logo links to home | Click "Alesha Auth Demo" → `/` | ✅ |
+| 6.4 | Active link is highlighted | Current page link has different style | ✅ |
+
+---
+
+## Package Comparison
+
+### Existing Testing Packages
+
+| Package | Purpose | Used For |
+|---------|---------|----------|
+| `vitest` | Unit/Component testing | `apps/web` route guards, smoke tests |
+| `bun:test` | Unit testing | All `@alesha-nov/*` packages |
+| `@testing-library/react` | React component testing | Component rendering |
+| `@playwright/test` | Browser automation E2E | **Now installed** |
+
+### Feature Coverage Matrix
+
+| Feature | Unit Tests | Integration Tests | E2E Tests |
+|---------|------------|-------------------|-----------|
+| Signup API | ✅ `auth-web` | ✅ Route tests | ✅ Signup page |
+| Login API | ✅ `auth-web` | ✅ Route tests | ✅ Login page |
+| Magic Link API | ✅ `auth-web` | ✅ Route tests | ✅ Magic link section |
+| Session Management | ✅ `auth-web` | ✅ Route tests | ✅ Full auth flow |
+| Protected Routes | ✅ Unit | ✅ Route guard | ✅ Dashboard |
+| Theme Toggle | ❌ No tests | ❌ No tests | ✅ Theme tests |
+| Navigation | ❌ No tests | ❌ No tests | ✅ Nav tests |
+
+---
+
+## Running E2E Tests
+
+```bash
+# Install browsers (one-time)
+npx playwright install chromium
+
+# Run all E2E tests
+bun run test:e2e
+
+# Run with UI mode
+bun run test:e2e:ui
+
+# Run headed (see browser)
+bun run test:e2e:headed
+```
+
+### Test Files
+
+```
+apps/web/
+├── e2e/
+│   ├── home.spec.ts        # Home page tests
+│   ├── signup.spec.ts      # Signup page + flow
+│   ├── login.spec.ts       # Login page + magic link
+│   ├── dashboard.spec.ts   # Protected route tests
+│   ├── theme.spec.ts       # Theme toggle tests
+│   └── navigation.spec.ts  # Header/nav tests
+├── playwright.config.ts    # Playwright configuration
+```
+
+### Notes
+
+- E2E tests run with a single worker to avoid state pollution from shared cookies/localStorage
+- Tests target `http://172.25.131.143:3000` by default
+- The dev server is automatically started by Playwright if not running

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -76,3 +76,35 @@ docker run --rm -p 3000:3000 \
 - Fail fast when `SESSION_SECRET` is missing
 - Use secure cookie settings in production
 - Replace demo magic-link UX with real email delivery flow
+
+## Testing
+
+### Unit & Integration Tests
+
+```bash
+bun run test
+```
+
+Test coverage:
+- `@alesha-nov/auth-web`: HTTP-level auth API tests (signup, login, magic-link, session, OAuth, roles, CORS)
+- `@alesha-nov/auth-react`: Hook and context tests
+- `apps/web`: Route guard tests, smoke tests
+
+### E2E Tests
+
+E2E tests use Playwright with Chromium. See [E2E-TESTING.md](./E2E-TESTING.md) for full checklist.
+
+**Covered by E2E tests (26 tests):**
+- Home page rendering and auth status display
+- Signup page form and account creation
+- Login page with email/password and magic-link
+- Dashboard protected route behavior
+- Theme toggle functionality (light/dark/auto)
+- Navigation links and active state
+
+**To run E2E tests:**
+```bash
+bun run test:e2e
+bun run test:e2e:ui      # Interactive UI mode
+bun run test:e2e:headed  # See browser while testing
+```

--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Dashboard Page (Protected Route)', () => {
+  test('redirects to login when not authenticated', async ({ page }) => {
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('shows dashboard when authenticated', async ({ page }) => {
+    await page.goto('/signup')
+    const timestamp = Date.now()
+    const email = `dashboard${timestamp}@example.com`
+    
+    await page.fill('input[placeholder="Name"]', 'Dashboard Test')
+    await page.fill('input[type="email"]', email)
+    await page.fill('input[type="password"]', 'password123')
+    await page.click('button[type="submit"]')
+    await expect(page.locator('text=/Signed up/')).toBeVisible({ timeout: 10000 })
+    
+    await page.goto('/dashboard')
+    await expect(page.locator('h1:has-text("Dashboard")')).toBeVisible()
+    await expect(page.locator(`text=${email}`)).toBeVisible()
+  })
+
+  test('logout button is visible and functional', async ({ page }) => {
+    await page.goto('/signup')
+    const timestamp = Date.now()
+    const email = `logout${timestamp}@example.com`
+    
+    await page.fill('input[placeholder="Name"]', 'Logout Test')
+    await page.fill('input[type="email"]', email)
+    await page.fill('input[type="password"]', 'password123')
+    await page.click('button[type="submit"]')
+    await expect(page.locator('text=/Signed up/')).toBeVisible({ timeout: 10000 })
+    
+    await page.goto('/dashboard')
+    await page.click('button:has-text("Logout")')
+    
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 })
+    await page.goto('/dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Home Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('page loads successfully', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('TanStack Start')
+  })
+
+  test('auth status shows unauthenticated', async ({ page }) => {
+    await expect(page.locator('text=Auth status:')).toBeVisible()
+    await expect(page.getByText('unauthenticated').first()).toBeVisible()
+  })
+
+  test('navigation links are visible', async ({ page }) => {
+    await expect(page.locator('nav >> text=Home')).toBeVisible()
+    await expect(page.locator('nav >> text=Signup')).toBeVisible()
+    await expect(page.locator('nav >> text=Login')).toBeVisible()
+    await expect(page.locator('nav >> text=Dashboard')).toBeVisible()
+  })
+
+  test('clicking signup link navigates to signup', async ({ page }) => {
+    await page.click('text=Go to Signup')
+    await expect(page).toHaveURL('/signup')
+  })
+
+  test('clicking login link navigates to login', async ({ page }) => {
+    await page.click('text=Go to Login')
+    await expect(page).toHaveURL('/login')
+  })
+
+  test('clicking dashboard when logged out redirects to login', async ({ page }) => {
+    await page.click('text=Open Dashboard')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Login Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login')
+  })
+
+  test('page loads with login form', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Login with email/password")')).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+    await expect(page.locator('button:has-text("Login")')).toBeVisible()
+  })
+
+  test('magic link section is visible', async ({ page }) => {
+    await expect(page.locator('h2:has-text("Magic link demo")')).toBeVisible()
+    await expect(page.locator('button:has-text("Request magic link token")')).toBeVisible()
+  })
+
+  test('login with invalid credentials shows error message', async ({ page }) => {
+    await page.fill('input[type="email"]', 'nonexistent@example.com')
+    await page.fill('input[type="password"]', 'wrongpassword')
+    await page.click('button:has-text("Login")')
+    
+    await expect(page.getByText(/invalid|failed|error/i)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('magic link request button is clickable', async ({ page }) => {
+    await page.locator('input[placeholder="Email"]').first().fill('test@example.com')
+    await page.click('button:has-text("Request magic link token")')
+    
+    await expect(page.locator('p.text-red-600, p.text-emerald-700')).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('header is sticky at top', async ({ page }) => {
+    const header = page.locator('header')
+    await expect(header).toBeVisible()
+    const position = await header.evaluate(el => getComputedStyle(el).position)
+    expect(position).toBe('sticky')
+  })
+
+  test('nav links navigate to correct pages', async ({ page }) => {
+    await page.click('nav >> text=Signup')
+    await expect(page).toHaveURL('/signup')
+    
+    await page.click('nav >> text=Login')
+    await expect(page).toHaveURL('/login')
+    
+    await page.click('nav >> text=Home')
+    await expect(page).toHaveURL('/')
+  })
+
+  test('logo links to home', async ({ page }) => {
+    await page.goto('/login')
+    await page.click('header a:has-text("Alesha Auth Demo")')
+    await expect(page).toHaveURL('/')
+  })
+
+  test('active link is highlighted', async ({ page }) => {
+    await page.goto('/login')
+    const activeLink = page.locator('nav a:has-text("Login").is-active, nav a:has-text("Login").nav-link.is-active')
+    await expect(activeLink).toBeVisible()
+  })
+})

--- a/apps/web/e2e/signup.spec.ts
+++ b/apps/web/e2e/signup.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Signup Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/signup')
+  })
+
+  test('page loads with signup form', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Signup')
+    await expect(page.locator('input[placeholder="Name"]')).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+    await expect(page.locator('button[type="submit"]')).toBeVisible()
+  })
+
+  test('submit empty form shows validation', async ({ page }) => {
+    await page.click('button[type="submit"]')
+    await expect(page.locator('input[type="email"]')).toHaveAttribute('required', '')
+  })
+
+  test('submit valid signup form', async ({ page }) => {
+    const timestamp = Date.now()
+    const email = `test${timestamp}@example.com`
+    
+    await page.fill('input[placeholder="Name"]', 'Test User')
+    await page.fill('input[type="email"]', email)
+    await page.fill('input[type="password"]', 'password123')
+    await page.click('button[type="submit"]')
+    
+    await expect(page.locator('text=/Signed up|Signed up:/')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('signup creates account and allows login', async ({ page, context }) => {
+    const timestamp = Date.now()
+    const email = `logintest${timestamp}@example.com`
+    const password = 'password123'
+    
+    await page.fill('input[placeholder="Name"]', 'Login Test')
+    await page.fill('input[type="email"]', email)
+    await page.fill('input[type="password"]', password)
+    await page.click('button[type="submit"]')
+    
+    await expect(page.locator('text=/Signed up/')).toBeVisible({ timeout: 10000 })
+    
+    await page.goto('/login')
+    await page.fill('input[type="email"]', email)
+    await page.fill('input[type="password"]', password)
+    await page.click('button:has-text("Login")')
+    
+    await page.waitForURL(/dashboard|/, { timeout: 10000 })
+  })
+})

--- a/apps/web/e2e/theme.spec.ts
+++ b/apps/web/e2e/theme.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Theme Toggle', () => {
+  test('shows Auto by default on fresh page', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+    await expect(page.locator('button:has-text("Auto")')).toBeVisible()
+  })
+
+  test('cycles through theme modes on click', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+    
+    const themeButton = page.locator('[title*="Theme mode"]')
+    
+    await expect(page.locator('button:has-text("Auto")')).toBeVisible()
+    
+    await themeButton.click()
+    await expect(page.locator('button:has-text("Light")')).toBeVisible()
+    
+    await themeButton.click()
+    await expect(page.locator('button:has-text("Dark")')).toBeVisible()
+    
+    await themeButton.click()
+    await expect(page.locator('button:has-text("Auto")')).toBeVisible()
+  })
+
+  test('theme persists after page reload', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+    
+    const themeButton = page.locator('[title*="Theme mode"]')
+    await themeButton.click()
+    await expect(page.locator('button:has-text("Light")')).toBeVisible()
+    
+    await page.reload()
+    await expect(page.locator('button:has-text("Light")')).toBeVisible()
+  })
+
+  test('clicking Light mode applies light class to html', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+    
+    const themeButton = page.locator('[title*="Theme mode"]')
+    await themeButton.click()
+    
+    const html = page.locator('html')
+    await expect(html).toHaveClass(/light/)
+  })
+
+  test('clicking Dark mode applies dark class to html', async ({ page, context }) => {
+    await context.clearCookies()
+    await page.goto('/')
+    
+    const themeButton = page.locator('[title*="Theme mode"]')
+    await themeButton.click()
+    await themeButton.click()
+    
+    const html = page.locator('html')
+    await expect(html).toHaveClass(/dark/)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,10 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts,.tsx",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage --coverage.reporter=text"
+    "test:coverage": "vitest run --coverage --coverage.reporter=text",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@alesha-nov/auth": "workspace:*",
@@ -35,6 +38,7 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "^10.4.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : 1,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://172.25.131.143:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    url: 'http://172.25.131.143:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+})

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,6 +4,6 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 export default defineConfig({
   plugins: [tsconfigPaths({ projects: ['./tsconfig.json'] })],
   test: {
-    exclude: ['e2e/**'],
+    exclude: ['e2e/**', '**/node_modules/**'],
   },
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths({ projects: ['./tsconfig.json'] })],
+  test: {
+    exclude: ['e2e/**'],
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@alesha-nov/auth": "workspace:*",
         "@alesha-nov/auth-react": "workspace:*",
@@ -39,6 +39,7 @@
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/devtools-vite": "latest",
         "@testing-library/dom": "^10.4.1",
@@ -57,7 +58,7 @@
     },
     "packages/auth": {
       "name": "@alesha-nov/auth",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@alesha-nov/db": "workspace:*",
         "@alesha-nov/email": "workspace:*",
@@ -80,7 +81,7 @@
     },
     "packages/auth-web": {
       "name": "@alesha-nov/auth-web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@alesha-nov/auth": "workspace:*",
       },
@@ -391,6 +392,8 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
@@ -607,9 +610,9 @@
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.24", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.32", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "magic-string": "^0.30.21", "prettier": "^3.5.0", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-VuusKwEXcgKq+myq1JQfZogY8scTXIIeFls50dJ/UXgCXWp5n14iFreYNlg41wURcak2oA3M+t2TVfD0xUUD6g=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.12", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.9", "@tanstack/router-generator": "1.166.24", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.10", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.22", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.32", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.21", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-wYPzIvBK8bcmXVUpZfSgGBXOrfBAdF4odKevz6rejio5rEd947NtKDF5R7eYdwlAOmRqYpLJnJ1QHkc5t8bY4w=="],
 
     "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.167.1", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-sJNRHa36lfuHw04akO9C6KU1P1Ncam2Azsk5XlgdQHMFgOtSlFAsuwqAHpyYSwu5Jyxj6P3PmyKYMIm4u8dI7Q=="],
 
@@ -724,8 +727,6 @@
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
-
-    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
@@ -1153,6 +1154,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
@@ -1182,8 +1187,6 @@
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
-    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -1272,8 +1275,6 @@
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
-
-    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1421,21 +1422,13 @@
 
     "@tanstack/devtools-vite/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
-
     "@tanstack/router-generator/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
-
-    "@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.166.32", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "magic-string": "^0.30.21", "prettier": "^3.5.0", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-VuusKwEXcgKq+myq1JQfZogY8scTXIIeFls50dJ/UXgCXWp5n14iFreYNlg41wURcak2oA3M+t2TVfD0xUUD6g=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.22", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.32", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.21", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-wYPzIvBK8bcmXVUpZfSgGBXOrfBAdF4odKevz6rejio5rEd947NtKDF5R7eYdwlAOmRqYpLJnJ1QHkc5t8bY4w=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1471,11 +1464,11 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -1505,17 +1498,9 @@
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "@tanstack/router-generator/@tanstack/router-core/cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
-
-    "@tanstack/router-plugin/@tanstack/router-core/cookie-es": ["cookie-es@2.0.1", "", {}, "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA=="],
-
     "@tanstack/router-plugin/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-generator/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -1543,16 +1528,10 @@
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
-
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
   }
 }


### PR DESCRIPTION
## Summary

Add E2E testing setup using Playwright with 26 tests covering:

- Home page rendering and auth status
- Signup page form validation and account creation
- Login page with email/password and magic-link
- Dashboard protected route behavior
- Theme toggle (light/dark/auto)
- Navigation links and active state

## Changes

- Add `playwright.config.ts` for test configuration
- Add 6 test spec files in `e2e/` directory
- Add `E2E-TESTING.md` documentation with feature checklist
- Update `package.json` with test scripts
- Update `README.md` with testing section

## Testing

```bash
bun run test:e2e      # Run all 26 tests
bun run test:e2e:ui   # Interactive UI mode
```

## Notes

Tests run with single worker to avoid state pollution from shared cookies/localStorage.