### PR TITLE
fix: prevent token exposure in magic link API

### DIFF
--- a/.changeset/fix-magic-link-no-token-exposure.md
+++ b/.changeset/fix-magic-link-no-token-exposure.md
@@ -1,0 +1,7 @@
+---
+"@alesha-nov/auth": patch
+"@alesha-nov/auth-web": patch
+"@alesha-nov/auth-react": patch
+---
+
+Fix magic link: API no longer returns token, email delivery handled by package

--- a/apps/web/src/routes/api.tsx
+++ b/apps/web/src/routes/api.tsx
@@ -334,7 +334,7 @@ function ApiPage() {
                   </div>
                   <div className="mt-3 space-y-2">
                     <p className="text-xs font-semibold text-[var(--sea-ink-soft)]">Example Responses</p>
-                    <ExampleResponse label="Token issued" status={200} body={{ token: 'ml_a1b2c3d4e5f6' }} />
+                    <ExampleResponse label="Email sent" status={200} body={{ sent: true }} />
                     <ExampleResponse label="Rate limited" status={429} body={{ error: 'Too many requests' }} />
                   </div>
                 </div>

--- a/packages/auth-react/src/hooks.ts
+++ b/packages/auth-react/src/hooks.ts
@@ -191,7 +191,7 @@ export function useMagicLinkRequest(config: AuthApiConfig = {}) {
       setError(null);
       setSent(false);
       try {
-        await postJson<{ token: string }>("/magic-link/request", input, config);
+        await postJson<{ sent: boolean }>("/magic-link/request", input, config);
         setSent(true);
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Magic link request failed";

--- a/packages/auth-web/src/index.test.ts
+++ b/packages/auth-web/src/index.test.ts
@@ -27,7 +27,7 @@ const makeAuthService = () => ({
     }
     return null;
   },
-  issueMagicLinkToken: async () => "magic-token",
+  issueMagicLinkToken: (() => {}) as unknown as (input: { email: string; ttlSeconds?: number }) => Promise<void>,
   issuePasswordResetToken: async ({ email }: { email: string }) => {
     if (email === "missing@example.com") throw new Error("User not found");
     return "reset-token";
@@ -412,13 +412,12 @@ describe("POST /sessions/revoke-all", () => {
 });
 
 describe("POST /magic-link/request", () => {
-  test("calls issueMagicLinkToken and returns 200 with token", async () => {
+  test("calls issueMagicLinkToken and returns 200 with sent: true", async () => {
     let called = false;
     const customService = makeAuthService();
     customService.issueMagicLinkToken = async ({ email }: { email: string }) => {
       called = true;
       expect(email).toBe("user@example.com");
-      return "request-token";
     };
 
     const app = createAuthWeb({
@@ -437,8 +436,8 @@ describe("POST /magic-link/request", () => {
 
     expect(response.status).toBe(200);
     expect(called).toBe(true);
-    const body = (await response.json()) as { token: string };
-    expect(body.token).toBe("request-token");
+    const body = (await response.json()) as { sent: boolean };
+    expect(body.sent).toBe(true);
   });
 });
 

--- a/packages/auth-web/src/index.ts
+++ b/packages/auth-web/src/index.ts
@@ -521,12 +521,12 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
         const limited = await checkRateLimit(request);
         if (limited) return limited;
         const body = await safeJson<{ email: string; ttlSeconds?: number }>(request);
-        const token = await options.authService.issueMagicLinkToken({
+        await options.authService.issueMagicLinkToken({
           email: body.email,
           ttlSeconds: body.ttlSeconds,
         });
 
-        return json(200, { token }, responseCorsHeaders);
+        return json(200, { sent: true }, responseCorsHeaders);
       }
 
       if (method === "POST" && subPath === "/magic-link/verify") {

--- a/packages/auth/src/service.oauth-magic.test.ts
+++ b/packages/auth/src/service.oauth-magic.test.ts
@@ -28,10 +28,8 @@ describe("createAuthService oauth + magic-link", () => {
     queue.push([{ id: "u-1" }], []);
 
     const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
-    const token = await svc.issueMagicLinkToken({ email: "user@example.com", ttlSeconds: 60 });
+    await svc.issueMagicLinkToken({ email: "user@example.com", ttlSeconds: 60 });
 
-    expect(typeof token).toBe("string");
-    expect(token.length > 10).toBe(true);
     expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_magic_link_tokens"))).toBe(true);
   });
 

--- a/packages/auth/src/service.ts
+++ b/packages/auth/src/service.ts
@@ -478,8 +478,6 @@ export async function createAuthService(
         ttlSeconds,
         expiresAt,
       });
-
-      return rawToken;
     },
 
     async verifyMagicLinkToken(token: string) {

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -216,7 +216,7 @@ export interface AuthService {
   validateOAuthCallback(input: OAuthCallbackValidationInput): OAuthCallbackValidationResult;
   issueSession(userId: string): Promise<AuthSession>;
   refreshSession(refreshToken: string): Promise<AuthSession | null>;
-  issueMagicLinkToken(input: MagicLinkInput): Promise<string>;
+  issueMagicLinkToken(input: MagicLinkInput): Promise<void>;
   verifyMagicLinkToken(token: string): Promise<AuthUser | null>;
   issuePasswordResetToken(input: PasswordResetInput): Promise<string>;
   resetPassword(input: ResetPasswordInput): Promise<boolean>;


### PR DESCRIPTION
## Summary
- Change `issueMagicLinkToken` to return `void` instead of exposing the token
- API endpoint `POST /auth/magic-link/request` now returns `{ sent: true }` instead of `{ token }`
- Token is sent via email only, as intended

## Changes
- `packages/auth/src/service.ts`: Remove token return value
- `packages/auth/src/types.ts`: Update return type to `Promise<void>`
- `packages/auth-web/src/index.ts`: Return `{ sent: true }` instead of `{ token }`
- `packages/auth/src/service.oauth-magic.test.ts`: Update test
- `packages/auth-web/src/index.test.ts`: Update test and mock
- `packages/auth-react/src/hooks.ts`: Update response type
- `apps/web/src/routes/api.tsx`: Update example response