### PR TITLE
fix: improve magic link request flow

### DIFF
--- a/.changeset/bright-buses-relax.md
+++ b/.changeset/bright-buses-relax.md
@@ -1,0 +1,10 @@
+---
+"@alesha-nov/auth": patch
+"@alesha-nov/auth-web": patch
+"@alesha-nov/config": patch
+"@alesha-nov/web": patch
+---
+
+Allow missing users to receive magic links by auto-creating accounts, wire magic-link email URLs to app origin, and reuse that link path for verification redirects.
+
+Also update the login demo page so the magic-link request input is separate from the password-login email field to avoid confusion.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,9 +1,69 @@
+# =============================================================================
+# APP
+# =============================================================================
+APP_ENV=development
+NODE_ENV=development
+APP_URL=http://localhost:3000
+APP_DEBUG=false
+APP_TIMEZONE=UTC
+
+# =============================================================================
+# DATABASE
+# =============================================================================
 DB_TYPE=sqlite
 DATABASE_URL=./alesha.sqlite
-# Generate locally:
-# openssl rand -hex 32
-# or
-# openssl rand -base64 48
-SESSION_SECRET=replace-with-long-random-string
-AUTH_SECURE_COOKIE=false
-NODE_ENV=development
+# For PostgreSQL: DB_TYPE=postgresql, DATABASE_URL=postgresql://user:pass@host:5432/dbname
+# For MySQL: DB_TYPE=mysql, DATABASE_URL=mysql://user:pass@host:3306/dbname
+
+# =============================================================================
+# AUTH - JWT
+# =============================================================================
+# Generate: openssl rand -hex 32
+AUTH_JWT_SECRET=replace-with-long-random-string
+
+# =============================================================================
+# AUTH - SESSION
+# =============================================================================
+AUTH_SESSION_COOKIE_NAME=alesha_session
+AUTH_SESSION_TTL_SECONDS=604800
+AUTH_SESSION_SECURE=false
+AUTH_SESSION_SAME_SITE=lax
+
+# =============================================================================
+# AUTH - MAGIC LINK
+# =============================================================================
+AUTH_EMAIL_FROM=noreply@example.com
+AUTH_MAGIC_LINK_TTL_SECONDS=900
+
+# =============================================================================
+# AUTH - EMAIL TRANSPORT
+# Choose one: SMTP or SES
+# =============================================================================
+
+# Option 1: SMTP
+AUTH_EMAIL_TRANSPORT=smtp
+AUTH_EMAIL_SMTP_HOST=smtp.example.com
+AUTH_EMAIL_SMTP_PORT=587
+AUTH_EMAIL_SMTP_SECURE=false
+AUTH_EMAIL_SMTP_USERNAME=
+AUTH_EMAIL_SMTP_PASSWORD=
+
+# Option 2: AWS SES
+# AUTH_EMAIL_TRANSPORT=ses
+# AUTH_EMAIL_SES_REGION=ap-southeast-1
+# AWS_ACCESS_KEY_ID=your-access-key
+# AWS_SECRET_ACCESS_KEY=your-secret-key
+
+# =============================================================================
+# AUTH - OAUTH (optional)
+# =============================================================================
+
+# Google OAuth
+# AUTH_OAUTH_GOOGLE_CLIENT_ID=
+# AUTH_OAUTH_GOOGLE_CLIENT_SECRET=
+# AUTH_OAUTH_GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback/google
+
+# GitHub OAuth
+# AUTH_OAUTH_GITHUB_CLIENT_ID=
+# AUTH_OAUTH_GITHUB_CLIENT_SECRET=
+# AUTH_OAUTH_GITHUB_REDIRECT_URI=http://localhost:3000/auth/callback/github

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "#/*": "./src/*"
   },
   "scripts": {
-    "dev": "bunx --bun vite dev --port 3000",
+    "dev": "bunx --bun vite dev --port 3000 --host 0.0.0.0",
     "build": "bunx --bun vite build",
     "preview": "bunx --bun vite preview",
     "typecheck": "tsc --noEmit",

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -21,6 +21,7 @@ function LoginPage() {
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [magicEmail, setMagicEmail] = useState('')
   const [token, setToken] = useState('')
 
   return (
@@ -45,11 +46,12 @@ function LoginPage() {
         <div className="island-shell rounded-2xl p-6">
           <h2 className="mb-3 text-xl font-semibold">Magic link demo</h2>
           <div className="space-y-3">
+            <input className="w-full rounded-md border p-2" placeholder="Email" type="email" value={magicEmail} onChange={(e) => setMagicEmail(e.target.value)} required />
             <button
               className="rounded-md border px-4 py-2"
               disabled={magicReq.loading}
               onClick={async () => {
-                await magicReq.request({ email })
+                await magicReq.request({ email: magicEmail })
               }}
               type="button"
             >

--- a/packages/auth-web/src/index.ts
+++ b/packages/auth-web/src/index.ts
@@ -529,6 +529,33 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
         return json(200, { sent: true }, responseCorsHeaders);
       }
 
+      if (method === "GET" && subPath === "/magic-link/verify") {
+        const limited = await checkRateLimit(request);
+        if (limited) return limited;
+        const url = new URL(request.url);
+        const token = url.searchParams.get("token");
+        if (!token) return json(400, { error: "Missing token parameter" }, responseCorsHeaders);
+
+        const user = await options.authService.verifyMagicLinkToken(token);
+        if (!user) return json(401, { error: "Invalid or expired token" }, responseCorsHeaders);
+
+        const publicUser = toPublicUser(user);
+        const session = newSession(publicUser);
+        const appUrl = request.headers.get("origin") ?? new URL(request.url).origin;
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            "Location": `${appUrl}/dashboard`,
+            "set-cookie": serializeCookie(cookieName, sessionCookieValue(session), {
+              maxAge: sessionTtlSeconds,
+              secure: secureCookie,
+            }),
+            ...responseCorsHeaders,
+          },
+        });
+      }
+
       if (method === "POST" && subPath === "/magic-link/verify") {
         const limited = await checkRateLimit(request);
         if (limited) return limited;

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -41,6 +41,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@alesha-nov/config": "workspace:*",
     "@alesha-nov/db": "workspace:*",
     "@alesha-nov/email": "workspace:*"
   },

--- a/packages/auth/src/service.test.ts
+++ b/packages/auth/src/service.test.ts
@@ -55,11 +55,13 @@ describe("createAuthService", () => {
     expect(result).toBeNull();
   });
 
-  test("issueMagicLinkToken throws when user does not exist", async () => {
+  test("issueMagicLinkToken creates user when missing", async () => {
     queue.push([]);
     const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
 
-    await expect(svc.issueMagicLinkToken({ email: "missing@example.com" })).rejects.toThrow("User not found");
+    await expect(svc.issueMagicLinkToken({ email: "missing@example.com" })).resolves.toBeUndefined();
+    expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_users"))).toBe(true);
+    expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_magic_link_tokens"))).toBe(true);
   });
 
   test("issueMagicLinkToken auto-delivers email when provider is configured", async () => {

--- a/packages/auth/src/service.ts
+++ b/packages/auth/src/service.ts
@@ -151,7 +151,11 @@ function buildDefaultAuthEmail(flow: AuthEmailFlow, context: AuthEmailDeliveryCo
 
   if (flow === "magic-link") {
     let appUrl = "http://localhost:3000";
-    try { appUrl = resolveAppConfig().url; } catch {}
+    try {
+      appUrl = resolveAppConfig().url;
+    } catch {
+      // Keep localhost default when app config is unavailable.
+    }
     const magicLinkUrl = `${appUrl}/auth/magic-link/verify?token=${encodeURIComponent(context.token)}`;
     const subject = "Your Magic Link";
     const html = `<p>Hi,</p><p>Click <a href="${magicLinkUrl}">here</a> to sign in. This link expires in ${expiresInMinutes} minutes.</p>`;

--- a/packages/auth/src/service.ts
+++ b/packages/auth/src/service.ts
@@ -1,4 +1,6 @@
 import { createDatabaseClient, runMigrations, type DBConfig } from "@alesha-nov/db";
+import { resolveAppConfig, resolveEmailTransportConfig, resolveMagicLinkConfig } from "@alesha-nov/config";
+import { createSesProvider, createSmtpProvider, type EmailProvider } from "@alesha-nov/email";
 import { randomBytes } from "node:crypto";
 import { authMigrations } from "./migrations";
 import type {
@@ -7,6 +9,7 @@ import type {
   AuthEmailDeliveryContext,
   AuthEmailFlow,
   AuthEmailFlowDeliveryOptions,
+  AuthEmailOptions,
   AuthService,
   AuthServiceOptions,
   AuthSession,
@@ -147,9 +150,12 @@ function buildDefaultAuthEmail(flow: AuthEmailFlow, context: AuthEmailDeliveryCo
   const expiresInMinutes = Math.max(1, Math.ceil(context.ttlSeconds / 60));
 
   if (flow === "magic-link") {
+    let appUrl = "http://localhost:3000";
+    try { appUrl = resolveAppConfig().url; } catch {}
+    const magicLinkUrl = `${appUrl}/auth/magic-link/verify?token=${encodeURIComponent(context.token)}`;
     const subject = "Your Magic Link";
-    const html = `<p>Hi,</p><p>Click <a href="${context.token}">here</a> to sign in. This link expires in ${expiresInMinutes} minutes.</p>`;
-    const text = `Hi,\n\nVisit this link to sign in: ${context.token}\nExpires in ${expiresInMinutes} minutes.`;
+    const html = `<p>Hi,</p><p>Click <a href="${magicLinkUrl}">here</a> to sign in. This link expires in ${expiresInMinutes} minutes.</p>`;
+    const text = `Hi,\n\nVisit this link to sign in: ${magicLinkUrl}\nExpires in ${expiresInMinutes} minutes.`;
     return { subject, html, text };
   }
 
@@ -240,6 +246,37 @@ function clearLoginFailures(loginAttempts: Map<string, LoginAttemptState>, key: 
   loginAttempts.delete(key);
 }
 
+function resolveEmailOptionsFromEnv(): AuthEmailOptions | undefined {
+  const transportConfig = resolveEmailTransportConfig();
+  if (!transportConfig) return undefined;
+
+  let provider: EmailProvider;
+  if (transportConfig.type === "ses") {
+    provider = createSesProvider({
+      region: transportConfig.ses!.region,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
+    });
+  } else {
+    provider = createSmtpProvider({
+      host: transportConfig.smtp!.host,
+      port: transportConfig.smtp!.port,
+      secure: transportConfig.smtp!.secure,
+      user: transportConfig.smtp!.username ?? "",
+      pass: transportConfig.smtp!.password ?? "",
+    });
+  }
+
+  let from: string;
+  try {
+    from = resolveMagicLinkConfig().sender;
+  } catch {
+    from = process.env.AUTH_EMAIL_FROM ?? process.env.EMAIL_FROM ?? "noreply@example.com";
+  }
+
+  return { provider, from };
+}
+
 export async function createAuthService(
   dbConfig: DBConfig,
   options: AuthServiceOptions = {},
@@ -248,10 +285,13 @@ export async function createAuthService(
   const client = providedClient ?? createDatabaseClient(dbConfig);
   await runMigrations(client, authMigrations);
 
-  const passwordPolicyValidator = options.passwordPolicyValidator ?? defaultPasswordPolicyValidator;
-  const auditSink = options.auditSink;
-  const loginProtection = options.loginProtection ?? DEFAULT_LOGIN_PROTECTION;
-  const sessionStrategy = options.sessionStrategy ?? new InMemoryAuthSessionStrategy();
+  const emailOptions = options.email ?? resolveEmailOptionsFromEnv();
+  const resolvedOptions: AuthServiceOptions = { ...options, email: emailOptions };
+
+  const passwordPolicyValidator = resolvedOptions.passwordPolicyValidator ?? defaultPasswordPolicyValidator;
+  const auditSink = resolvedOptions.auditSink;
+  const loginProtection = resolvedOptions.loginProtection ?? DEFAULT_LOGIN_PROTECTION;
+  const sessionStrategy = resolvedOptions.sessionStrategy ?? new InMemoryAuthSessionStrategy();
   const loginAttempts = new Map<string, LoginAttemptState>();
 
   return {
@@ -458,8 +498,28 @@ export async function createAuthService(
       const rows = await client.sql`
         SELECT id FROM auth_users WHERE email = ${email} LIMIT 1
       `;
-      const user = rows[0] as { id: string } | undefined;
-      if (!user) throw new Error("User not found");
+      let user = rows[0] as { id: string } | undefined;
+
+      if (!user) {
+        const userId = newId();
+        const generatedPasswordHash = hashPassword(randomBytes(48).toString("hex"));
+        const now = new Date().toISOString();
+
+        await client.sql`
+          INSERT INTO auth_users (id, email, password_hash, name, image, email_verified_at)
+          VALUES (${userId}, ${email}, ${generatedPasswordHash}, NULL, NULL, ${now})
+        `;
+
+        await emitAuditEvent(auditSink, {
+          type: "SIGNUP",
+          userId,
+          email,
+          metadata: { roleCount: 0 },
+          occurredAt: now,
+        });
+
+        user = { id: userId };
+      }
 
       const rawToken = randomBytes(32).toString("base64url");
       const tokenHash = hashToken(rawToken);
@@ -471,7 +531,7 @@ export async function createAuthService(
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
 
-      await maybeDeliverAuthTokenEmail(options, "magic-link", {
+      await maybeDeliverAuthTokenEmail(resolvedOptions, "magic-link", {
         flow: "magic-link",
         email,
         token: rawToken,
@@ -550,7 +610,7 @@ export async function createAuthService(
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
 
-      await maybeDeliverAuthTokenEmail(options, "password-reset", {
+      await maybeDeliverAuthTokenEmail(resolvedOptions, "password-reset", {
         flow: "password-reset",
         email,
         token: rawToken,
@@ -642,7 +702,7 @@ export async function createAuthService(
         VALUES (${tokenHash}, ${user.id}, ${expiresAt})
       `;
 
-      await maybeDeliverAuthTokenEmail(options, "email-verification", {
+      await maybeDeliverAuthTokenEmail(resolvedOptions, "email-verification", {
         flow: "email-verification",
         email,
         token: rawToken,

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -10,6 +10,7 @@ Auth and email environment configuration resolvers for the monorepo.
 - `resolveMagicLinkConfig()`
 - `resolveEmailTransportConfig()` (SES/SMTP with validation)
 - `resolveOAuthConfig()` (Google/GitHub)
+- `resolveAppConfig()`
 
 ## Required for Target Auth (Email/Password, Magic Link, Google/GitHub)
 

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  resolveAppConfig,
   resolveEmailTransportConfig,
   resolveJWTSecret,
   resolveMagicLinkConfig,
@@ -44,6 +45,11 @@ const ENV_KEYS = [
   "EMAIL_SMTP_USERNAME",
   "AUTH_EMAIL_SMTP_PASSWORD",
   "EMAIL_SMTP_PASSWORD",
+  "APP_ENV",
+  "NODE_ENV",
+  "APP_URL",
+  "APP_DEBUG",
+  "APP_TIMEZONE",
 ] as const;
 
 afterEach(() => {
@@ -277,5 +283,49 @@ describe("resolveOAuthConfig", () => {
   test("throws when provider config is incomplete", () => {
     process.env.AUTH_OAUTH_GITHUB_CLIENT_ID = "github-id";
     expect(() => resolveOAuthConfig()).toThrow("Incomplete github OAuth env");
+  });
+});
+
+describe("resolveAppConfig", () => {
+  test("returns defaults when app env is missing", () => {
+    expect(resolveAppConfig()).toEqual({
+      env: "development",
+      url: "http://localhost:3000",
+      debug: true,
+      timezone: "UTC",
+    });
+  });
+
+  test("reads app env and url from explicit vars", () => {
+    process.env.APP_ENV = "production";
+    process.env.APP_URL = "https://app.example.test";
+    process.env.APP_DEBUG = "false";
+    process.env.APP_TIMEZONE = "Asia/Jakarta";
+
+    expect(resolveAppConfig()).toEqual({
+      env: "production",
+      url: "https://app.example.test",
+      debug: false,
+      timezone: "Asia/Jakarta",
+    });
+  });
+
+  test("falls back to NODE_ENV when APP_ENV is missing", () => {
+    process.env.NODE_ENV = "test";
+
+    expect(resolveAppConfig()).toMatchObject({
+      env: "test",
+      debug: false,
+    });
+  });
+
+  test("throws when APP_ENV value is invalid", () => {
+    process.env.APP_ENV = "staging";
+    expect(() => resolveAppConfig()).toThrow("Invalid APP_ENV/NODE_ENV");
+  });
+
+  test("throws when APP_DEBUG is invalid", () => {
+    process.env.APP_DEBUG = "yes";
+    expect(() => resolveAppConfig()).toThrow("Invalid app debug");
   });
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -50,6 +50,13 @@ export interface OAuthConfig {
   github?: OAuthProviderConfig;
 }
 
+export interface AppConfig {
+  env: "development" | "production" | "test";
+  url: string;
+  debug: boolean;
+  timezone: string;
+}
+
 function readEnv(keys: string[]): string | undefined {
   for (const key of keys) {
     const value = process.env[key]?.trim();
@@ -252,4 +259,21 @@ export function resolveOAuthConfig(): OAuthConfig {
     google: resolveOAuthProviderConfig("google"),
     github: resolveOAuthProviderConfig("github"),
   };
+}
+
+export function resolveAppConfig(): AppConfig {
+  const nodeEnv = readEnv(["APP_ENV", "NODE_ENV"]) ?? "development";
+  const validEnvs = ["development", "production", "test"];
+  if (!validEnvs.includes(nodeEnv)) {
+    throw new Error(`Invalid APP_ENV/NODE_ENV. Supported values: ${validEnvs.join(" | ")}`);
+  }
+
+  const url = readEnv(["APP_URL"]) ?? "http://localhost:3000";
+
+  const debugRaw = readEnv(["APP_DEBUG"]);
+  const debug = debugRaw ? parseBoolean(debugRaw, "app debug") : nodeEnv === "development";
+
+  const timezone = readEnv(["APP_TIMEZONE"]) ?? "UTC";
+
+  return { env: nodeEnv as AppConfig["env"], url, debug, timezone };
 }


### PR DESCRIPTION
## Summary

- Allow magic-link requests for unknown emails by auto-provisioning a minimal account before issuing a token.
- Use app/env config to build magic-link URLs and resolve email transport and sender from environment so links are delivered consistently.
- Add `GET /auth/magic-link/verify` to `@alesha-nov/auth-web` so link clicks create a session and redirect to `/dashboard`.
- Update login demo page with a separate magic-link email input to avoid mixing with password-login email.
- Update config docs and sample `.env` for new app/email settings.

## Validation

- Ran `bun run lint`.
- Ran `bun run test`.
- Added changeset `.changeset/bright-buses-relax.md`.
