### PR TITLE
Add bearer token session support and role-permission checks

### DIFF
--- a/.changeset/bright-buses-relax.md
+++ b/.changeset/bright-buses-relax.md
@@ -2,7 +2,6 @@
 "@alesha-nov/auth": patch
 "@alesha-nov/auth-web": patch
 "@alesha-nov/config": patch
-"@alesha-nov/web": patch
 ---
 
 Allow missing users to receive magic links by auto-creating accounts, wire magic-link email URLs to app origin, and reuse that link path for verification redirects.

--- a/docs/apps/api.md
+++ b/docs/apps/api.md
@@ -320,12 +320,23 @@ curl -b "alesha_auth=<token>" http://172.25.131.143:3000/auth/linked-accounts
 
 ### PUT /auth/roles
 
-Update roles for a user. Requires session with `support.write` or `billing.write` role to update other users.
+Update roles for a user.
+
+Permission checks:
+
+- Own-user updates require `roles:write`.
+- Cross-user updates require `roles:write:any`.
 
 ```bash
 curl -X PUT http://172.25.131.143:3000/auth/roles \
   -H "Content-Type: application/json" \
   -b "alesha_auth=<token>" \
+  -d '{"userId":"01921abc-...","roles":["user","support.read"]}'
+
+# or (Bearer token)
+curl -X PUT http://172.25.131.143:3000/auth/roles \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
   -d '{"userId":"01921abc-...","roles":["user","support.read"]}'
 ```
 

--- a/docs/packages/auth-web.md
+++ b/docs/packages/auth-web.md
@@ -106,11 +106,12 @@ POST /auth/logout
 
 ### GET /auth/session
 
-Get current session (requires valid cookie).
+Get current session (requires valid session).
 
 ```http
 GET /auth/session
 Cookie: alesha_auth=...
+Authorization: Bearer <token>
 ```
 
 **Response (200):**
@@ -200,7 +201,16 @@ Cookie: alesha_auth=...
 
 ### PUT /auth/roles
 
-Update roles for a user. Requires `support.write` or `billing.write` role to update other users.
+Update roles for a user.
+
+- Update your own roles: requires `roles:write` permission.
+- Update another user's roles: requires `roles:write:any` permission.
+
+Built-in role mapping currently resolves:
+
+- `admin` -> `roles:write`
+- `support.write` -> `roles:write`, `roles:write:any`
+- `billing.write` -> `roles:write`, `roles:write:any`
 
 ```http
 PUT /auth/roles
@@ -232,6 +242,13 @@ const session = await getSessionFromRequest(request, sessionSecret, cookieName);
 // → AuthSession | null
 ```
 
+`getSessionFromRequest` reads token from either `Cookie` or `Authorization: Bearer`.
+
 ## Session Token Format
 
-The session token is a signed JWT-like structure: `{b64url(payload)}.{b64url(signature)}`, signed with HMAC-SHA256 using the `sessionSecret`. The payload contains the `AuthSession` object.
+The session token supports two formats:
+
+1) Internal format: `{b64url(payload)}.{b64url(signature)}`
+2) Standard JWT-like format: `{b64url(header)}.{b64url(payload)}.{b64url(signature)}`
+
+Both use HMAC-SHA256, `sessionSecret`, and the same expiry semantics.

--- a/packages/auth-web/src/index.test.ts
+++ b/packages/auth-web/src/index.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, test } from "bun:test";
 import { createAuthWeb, getSessionFromRequest, revokeAllUserTokens, revokeSession, type RateLimiter } from "./index";
+import { createHmac } from "node:crypto";
+
+function base64url(value: string): string {
+  return Buffer.from(value, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function signJwt(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("base64url");
+}
+
+function buildJwt(parts: {
+  userId: string;
+  email: string;
+  roles: string[];
+  expSeconds: number;
+  secret: string;
+}): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({
+      sub: parts.userId,
+      email: parts.email,
+      roles: parts.roles,
+      exp: parts.expSeconds,
+    }),
+  );
+  const signature = signJwt(`${header}.${payload}`, parts.secret);
+  return `${header}.${payload}.${signature}`;
+}
 
 const makeAuthService = () => ({
   signup: async (input: { email: string; name?: string; image?: string; roles?: string[] }) => ({
@@ -206,6 +239,59 @@ describe("createAuthWeb", () => {
     );
 
     expect(response.status).toBe(403);
+    expect((await response.json()).error).toBe("Insufficient permissions");
+  });
+
+  test("roles endpoint allows cross-user update with support.write permission", async () => {
+    const privilegedService = makeAuthService();
+    privilegedService.login = async (input: { email: string }) => {
+      if (input.email === "priv@example.com") {
+        return {
+          id: "u-2",
+          email: "priv@example.com",
+          passwordHash: "hashed",
+          name: "Priv",
+          image: null,
+          emailVerifiedAt: null,
+          roles: ["support.write"],
+          createdAt: "2024-01-01T00:00:00.000Z",
+        };
+      }
+
+      return null;
+    };
+
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: privilegedService,
+      secureCookie: false,
+    });
+
+    const loginResponse = await app.handleRequest(
+      new Request("http://localhost/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "priv@example.com", password: "x" }),
+      })
+    );
+
+    const cookie = loginResponse.headers.get("set-cookie") ?? "";
+
+    const response = await app.handleRequest(
+      new Request("http://localhost/auth/roles", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          cookie,
+        },
+        body: JSON.stringify({ userId: "someone-else", roles: ["billing.write"] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { userId: string; roles: string[] };
+    expect(body.userId).toBe("someone-else");
+    expect(body.roles).toEqual(["billing.write"]);
   });
 
   test("safeJson error path returns 400", async () => {
@@ -230,6 +316,71 @@ describe("getSessionFromRequest", () => {
   test("returns null when cookie is missing", async () => {
     const session = await getSessionFromRequest(new Request("http://localhost/auth/session"), "0123456789abcdef");
     expect(session).toBeNull();
+  });
+
+  test("reads valid Bearer token from Authorization header", async () => {
+    const sessionPayload = {
+      userId: "jwt-user",
+      email: "jwt@example.com",
+      roles: ["admin"],
+      expSeconds: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const jwt = buildJwt({
+      userId: sessionPayload.userId,
+      email: sessionPayload.email,
+      roles: sessionPayload.roles,
+      expSeconds: sessionPayload.expSeconds,
+      secret: "0123456789abcdef",
+    });
+
+    const session = await getSessionFromRequest(
+      new Request("http://localhost/auth/session", {
+        headers: {
+          authorization: `Bearer ${jwt}`,
+        },
+      }),
+      "0123456789abcdef",
+    );
+
+    expect(session).toEqual({
+      userId: "jwt-user",
+      email: "jwt@example.com",
+      roles: ["admin"],
+      exp: sessionPayload.expSeconds,
+      sessionId: expect.any(String),
+    });
+  });
+
+  test("falls back to cookie when Authorization header is absent", async () => {
+    const app = createAuthWeb({
+      sessionSecret: "0123456789abcdef",
+      authService: makeAuthService(),
+      secureCookie: false,
+    });
+
+    const loginResponse = await app.handleRequest(
+      new Request("http://localhost/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "ok@example.com", password: "x" }),
+      })
+    );
+
+    const cookie = loginResponse.headers.get("set-cookie") ?? "";
+    const token = cookie.split(";")[0]?.split("=")[1] ?? "";
+    expect(token).not.toBe("");
+
+    const session = await getSessionFromRequest(
+      new Request("http://localhost/auth/session", {
+        headers: {
+          cookie: `alesha_auth=${token}`,
+        },
+      }),
+      "0123456789abcdef",
+    );
+
+    expect(session).toMatchObject({ userId: "u-1", email: "ok@example.com", roles: ["admin"] });
   });
 });
 

--- a/packages/auth-web/src/index.ts
+++ b/packages/auth-web/src/index.ts
@@ -117,6 +117,39 @@ function hashToken(token: string): string {
   return Buffer.from(token, "utf-8").toString("hex");
 }
 
+const ROLE_PERMISSION_MAP: Record<string, string[]> = {
+  admin: ["roles:write"],
+  "support.write": ["roles:write", "roles:write:any"],
+  "billing.write": ["roles:write", "roles:write:any"],
+};
+
+function derivePermissionsFromRoles(roles: string[]): string[] {
+  const permissions = new Set<string>();
+
+  for (const role of roles) {
+    const mapped = ROLE_PERMISSION_MAP[role] ?? [role];
+    for (const permission of mapped) {
+      permissions.add(permission);
+    }
+  }
+
+  return [...permissions];
+}
+
+function hasPermission(roles: string[], requiredPermission: string): boolean {
+  if (roles.includes("*") || roles.includes("*:") || roles.includes("*:*")) {
+    return true;
+  }
+
+  const permissions = derivePermissionsFromRoles(roles);
+  const exact = permissions.includes(requiredPermission);
+  if (exact) return true;
+
+  return permissions.some((permission) =>
+    permission.startsWith(`${requiredPermission}:`) || permission === "*"
+  );
+}
+
 function createSessionToken(session: AuthSession, secret: string): string {
   const payload = b64url(JSON.stringify(session));
   const sig = sign(payload, secret);
@@ -124,22 +157,93 @@ function createSessionToken(session: AuthSession, secret: string): string {
 }
 
 function verifySessionToken(token: string, secret: string): AuthSession | null {
-  const [payload, sig] = token.split(".");
-  if (!payload || !sig) return null;
+  const nowSeconds = Math.floor(Date.now() / 1000);
 
-  const expectedSig = sign(payload, secret);
-  const sigOk = timingSafeEqual(Buffer.from(sig), Buffer.from(expectedSig));
-  if (!sigOk) return null;
+  const parts = token.split(".");
+  if (parts.length === 2) {
+    const [payloadB64, sigB64] = parts;
+    if (!payloadB64 || !sigB64) return null;
 
-  const parsed = JSON.parse(b64urlDecode(payload)) as AuthSession;
-  if (!parsed.exp || parsed.exp < Math.floor(Date.now() / 1000)) return null;
+    const expectedSig = sign(payloadB64, secret);
+    const sigOk = timingSafeEqual(Buffer.from(sigB64), Buffer.from(expectedSig));
+    if (!sigOk) return null;
 
-  // Check revocation list
-  const tokenHash = hashToken(token);
-  const revokedAt = revokedSessions.get(tokenHash);
-  if (revokedAt !== undefined) return null;
+    let payload: AuthSession;
+    try {
+      payload = JSON.parse(b64urlDecode(payloadB64)) as AuthSession;
+    } catch {
+      return null;
+    }
 
-  return parsed;
+    if (!payload.exp || payload.exp < nowSeconds) return null;
+
+    const tokenHash = hashToken(token);
+    if (revokedSessions.has(tokenHash)) return null;
+
+    return payload;
+  }
+
+  if (parts.length === 3) {
+    const [headerB64, payloadB64, sigB64] = parts;
+    if (!headerB64 || !payloadB64 || !sigB64) return null;
+
+    const expectedSig = sign(`${headerB64}.${payloadB64}`, secret);
+    const sigOk = timingSafeEqual(Buffer.from(sigB64), Buffer.from(expectedSig));
+    if (!sigOk) return null;
+
+    let header: { alg?: string };
+    try {
+      header = JSON.parse(b64urlDecode(headerB64)) as { alg?: string };
+    } catch {
+      return null;
+    }
+
+    if (header.alg && header.alg !== "HS256") return null;
+
+    let payload: {
+      sub?: string;
+      email?: string;
+      roles?: unknown;
+      exp?: number;
+      sessionId?: string;
+      iat?: number;
+    };
+    try {
+      payload = JSON.parse(b64urlDecode(payloadB64));
+    } catch {
+      return null;
+    }
+
+    const exp = Number(payload.exp);
+    if (!Number.isFinite(exp) || exp < nowSeconds) return null;
+
+    if (!payload.sub || typeof payload.sub !== "string") return null;
+    if (!payload.email || typeof payload.email !== "string") return null;
+    if (payload.roles !== undefined && !Array.isArray(payload.roles)) return null;
+
+    const roles =
+      payload.roles === undefined
+        ? []
+        : payload.roles.map((role) => String(role));
+
+    const tokenHash = hashToken(token);
+    if (revokedSessions.has(tokenHash)) return null;
+
+    return {
+      userId: payload.sub,
+      email: payload.email,
+      roles,
+      exp,
+      sessionId: payload.sessionId ?? `${payload.sub}:${iatFallback(exp, payload.iat)}`,
+    };
+  }
+
+  return null;
+}
+
+function iatFallback(exp: number, iat: unknown): string {
+  if (typeof iat === "number" && iat > 0) return String(iat);
+  return String(exp);
 }
 
 export function revokeSession(token: string): void {
@@ -373,9 +477,16 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
 
   function getSessionFromRequest(request: Request): AuthSession | null {
     const cookies = parseCookies(request);
-    const token = cookies[cookieName];
-    if (!token) return null;
-    return verifySessionToken(token, options.sessionSecret);
+    const cookieToken = cookies[cookieName];
+    if (cookieToken) return verifySessionToken(cookieToken, options.sessionSecret);
+
+    const authHeader = request.headers.get("authorization");
+    const authToken = authHeader?.trim().startsWith("Bearer ")
+      ? authHeader.trim().slice(7).trim()
+      : null;
+
+    if (!authToken) return null;
+    return verifySessionToken(authToken, options.sessionSecret);
   }
 
   async function authenticateFromSession(request: Request): Promise<AuthSession> {
@@ -787,8 +898,12 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
         const body = await safeJson<{ userId?: string; roles: string[] }>(request);
         const targetUserId = body.userId ?? current.userId;
 
-        if (targetUserId !== current.userId && !current.roles.includes("support.write") && !current.roles.includes("billing.write")) {
-          return json(403, { error: "Forbidden" }, responseCorsHeaders);
+        if (!hasPermission(current.roles, "roles:write")) {
+          return json(403, { error: "Insufficient permissions" }, responseCorsHeaders);
+        }
+
+        if (targetUserId !== current.userId && !hasPermission(current.roles, "roles:write:any")) {
+          return json(403, { error: "Insufficient permissions" }, responseCorsHeaders);
         }
 
         const roles = await options.authService.setUserRoles(targetUserId, body.roles ?? []);
@@ -810,7 +925,15 @@ export function createAuthWeb(options: AuthWebOptions): AuthRouteHandlers {
 
 export async function getSessionFromRequest(request: Request, sessionSecret: string, cookieName = "alesha_auth"): Promise<AuthSession | null> {
   const cookies = parseCookies(request);
-  const token = cookies[cookieName];
-  if (!token) return null;
-  return verifySessionToken(token, sessionSecret);
+  const cookieToken = cookies[cookieName];
+  if (cookieToken) {
+    const cookieSession = verifySessionToken(cookieToken, sessionSecret);
+    if (cookieSession) return cookieSession;
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const authToken = authHeader?.trim().startsWith("Bearer ") ? authHeader.trim().slice(7).trim() : null;
+  if (!authToken) return null;
+
+  return verifySessionToken(authToken, sessionSecret);
 }


### PR DESCRIPTION
## Summary
- Add role-permission based `/roles` authorization in `@alesha-nov/auth-web` with explicit `roles:write` and `roles:write:any` checks.
- Extend session parsing to support `Authorization: Bearer <token>` in addition to existing cookie-based auth, including internal and JWT-like token formats.
- Update docs and tests for the new auth/token and roles behavior.

## Test Plan
- [x] bun test packages/auth-web
- [x] bun test packages/auth-web/src/index.test.ts
