### PR TITLE
feat(auth): assign default roles on user creation

### DIFF
--- a/packages/auth/src/service.core.test.ts
+++ b/packages/auth/src/service.core.test.ts
@@ -117,4 +117,93 @@ describe("createAuthService core auth", () => {
     expect(roles).toEqual(["admin", "editor"]);
     expect(sqlCalls.some((c) => c.text.includes("SELECT role") && c.text.includes("FROM auth_user_roles"))).toBe(true);
   });
+
+  test("signup without roles assigns default 'user' role", async () => {
+    queue.push(
+      [],
+      [],
+      [
+        {
+          id: "u-new",
+          email: "newbie@example.com",
+          password_hash: "hash",
+          name: null,
+          image: null,
+          email_verified_at: null,
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      [{ role: "user" }]
+    );
+
+    const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
+    const result = await svc.signup({
+      email: "Newbie@example.com",
+      password: "secret",
+    });
+
+    expect(result.roles).toEqual(["user"]);
+    expect(sqlCalls.filter((c) => c.text.includes("INSERT INTO auth_user_roles"))).toHaveLength(1);
+  });
+
+  test("signup with explicit roles does not get default roles", async () => {
+    queue.push(
+      [],
+      [],
+      [
+        {
+          id: "u-admin",
+          email: "admin@example.com",
+          password_hash: "hash",
+          name: null,
+          image: null,
+          email_verified_at: null,
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      [{ role: "admin" }]
+    );
+
+    const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
+    const result = await svc.signup({
+      email: "Admin@example.com",
+      password: "secret",
+      roles: ["admin"],
+    });
+
+    expect(result.roles).toEqual(["admin"]);
+    expect(sqlCalls.filter((c) => c.text.includes("INSERT INTO auth_user_roles"))).toHaveLength(1);
+  });
+
+  test("signup with custom defaultRoles option uses those instead of 'user'", async () => {
+    queue.push(
+      [],
+      [],
+      [],
+      [
+        {
+          id: "u-custom",
+          email: "custom@example.com",
+          password_hash: "hash",
+          name: null,
+          image: null,
+          email_verified_at: null,
+          created_at: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      [{ role: "member" }, { role: "viewer" }]
+    );
+
+    const svc = await createAuthService(
+      { type: "sqlite", url: ":memory:" },
+      { defaultRoles: ["member", "viewer"] }
+    );
+    const result = await svc.signup({
+      email: "Custom@example.com",
+      password: "secret",
+    });
+
+    expect(result.roles).toEqual(["member", "viewer"]);
+    expect(sqlCalls.filter((c) => c.text.includes("INSERT INTO auth_user_roles"))).toHaveLength(2);
+  });
 });

--- a/packages/auth/src/service.oauth-magic.test.ts
+++ b/packages/auth/src/service.oauth-magic.test.ts
@@ -33,6 +33,19 @@ describe("createAuthService oauth + magic-link", () => {
     expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_magic_link_tokens"))).toBe(true);
   });
 
+  test("issueMagicLinkToken creates new user with default 'user' role when user does not exist", async () => {
+    queue.push([], [{ id: "u-new" }], []);
+    mock.module("@alesha-nov/email", () => ({
+      sendAuthEmail: async () => {},
+    }));
+
+    const svc = await createAuthService({ type: "sqlite", url: ":memory:" });
+    await svc.issueMagicLinkToken({ email: "newuser@example.com", ttlSeconds: 60 });
+
+    expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_users"))).toBe(true);
+    expect(sqlCalls.some((c) => c.text.includes("INSERT INTO auth_user_roles"))).toBe(true);
+  });
+
   test("verifyMagicLinkToken returns user and marks token used", async () => {
     queue.push(
       [

--- a/packages/auth/src/service.ts
+++ b/packages/auth/src/service.ts
@@ -297,6 +297,7 @@ export async function createAuthService(
   const loginProtection = resolvedOptions.loginProtection ?? DEFAULT_LOGIN_PROTECTION;
   const sessionStrategy = resolvedOptions.sessionStrategy ?? new InMemoryAuthSessionStrategy();
   const loginAttempts = new Map<string, LoginAttemptState>();
+  const defaultRoles = normalizeRoles(resolvedOptions.defaultRoles ?? ["user"]);
 
   return {
     async signup(input: SignupInput) {
@@ -308,7 +309,8 @@ export async function createAuthService(
       }
 
       const passwordHash = hashPassword(input.password);
-      const roles = normalizeRoles(input.roles ?? []);
+      const inputRoles = input.roles ?? [];
+      const roles = normalizeRoles(inputRoles.length > 0 ? inputRoles : defaultRoles);
 
       await client.sql`
         INSERT INTO auth_users (id, email, password_hash, name, image)
@@ -514,11 +516,18 @@ export async function createAuthService(
           VALUES (${userId}, ${email}, ${generatedPasswordHash}, NULL, NULL, ${now})
         `;
 
+        for (const role of defaultRoles) {
+          await client.sql`
+            INSERT INTO auth_user_roles (user_id, role)
+            VALUES (${userId}, ${role})
+          `;
+        }
+
         await emitAuditEvent(auditSink, {
           type: "SIGNUP",
           userId,
           email,
-          metadata: { roleCount: 0 },
+          metadata: { roleCount: defaultRoles.length },
           occurredAt: now,
         });
 
@@ -868,7 +877,8 @@ export async function createAuthService(
           )
         `;
 
-        const newRoles = normalizeRoles(input.roles ?? []);
+        const oauthInputRoles = input.roles ?? [];
+        const newRoles = normalizeRoles(oauthInputRoles.length > 0 ? oauthInputRoles : defaultRoles);
         for (const role of newRoles) {
           await client.sql`
             INSERT INTO auth_user_roles (user_id, role)

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -198,6 +198,7 @@ export interface AuthServiceOptions {
   loginProtection?: LoginProtectionConfig;
   sessionStrategy?: AuthSessionStrategy;
   email?: AuthEmailOptions;
+  defaultRoles?: string[];
 }
 
 export interface OAuthAuthorizationProviderConfig {


### PR DESCRIPTION
## Summary

Fixes the issue where new users created via magic link or signup get **zero roles**, causing the dashboard to show `Roles: -`.

When a user is created without explicit roles (via magic link, OAuth, or signup), the `@alesha-nov/auth` service now assigns a default `["user"]` role automatically.

### Changes

- Add `defaultRoles?: string[]` option to `AuthServiceOptions` (defaults to `["user"]`)
- Applied in 3 places:
  - `signup()` — falls back to `defaultRoles` when no roles provided
  - `issueMagicLinkToken()` — inserts `defaultRoles` into `auth_user_roles` when auto-creating user
  - `loginWithOAuth()` — falls back to `defaultRoles` for new OAuth users

### Role → Permission mapping

The `"user"` role derives no special permissions by default (since `ROLE_PERMISSION_MAP` doesn't map `"user"`). Users can still update their own roles if `roles:write` permission is granted to the `"user"` role via custom mapping.

### Test Plan

- [x] bun test packages/auth/src/service.core.test.ts
- [x] bun test packages/auth/src/service.oauth-magic.test.ts
- [x] bun test packages/auth-web/src/index.test.ts