### PR TITLE
fix(docker): build auth-react before web build in GHCR image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,13 @@ COPY packages ./packages
 
 RUN bun install --frozen-lockfile
 COPY . .
-RUN bun run build
+RUN bun run --filter @alesha-nov/config build && \
+    bun run --filter @alesha-nov/db build && \
+    bun run --filter @alesha-nov/email build && \
+    bun run --filter @alesha-nov/auth build && \
+    bun run --filter @alesha-nov/auth-web build && \
+    bun run --filter @alesha-nov/auth-react build && \
+    bun run --filter web build
 
 FROM oven/bun:1.3.11 AS runner
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Update `Dockerfile` builder stage to build workspace packages explicitly before `web` build.
- Ensure `@alesha-nov/auth-react` is built before `bun run --filter web build` so exported `dist/*` exists during Vite resolution.
- Add explicit build order for internal package dependencies used by `web` (`config`, `db`, `email`, `auth`, `auth-web`, `auth-react`).

## Why
GitHub Docker GHCR build failed when `web` build tried to resolve workspace package exports that point to `dist/*` before those artifacts existed in container build context. This addresses Issue #77.

## Validation
- Local Docker build passed:
  - `docker build -f Dockerfile -t alesha-web-issue77:test .`

Fixes #77
