### PR TITLE
feat(web): integrate @alesha-nov/config and @alesha-nov/email

### DIFF
--- a/apps/web/src/server/auth-config.ts
+++ b/apps/web/src/server/auth-config.ts
@@ -1,25 +1,9 @@
-const DEFAULT_DEV_SESSION_SECRET = 'dev-session-secret-change-me'
-
-function isProductionEnv(): boolean {
-  return process.env.NODE_ENV === 'production'
-}
+import { resolveSessionConfig, resolveJWTSecret } from '@alesha-nov/config'
 
 export function resolveSessionSecret(): string {
-  const fromEnv = process.env.SESSION_SECRET?.trim()
-  if (fromEnv) return fromEnv
-
-  if (isProductionEnv()) {
-    throw new Error('SESSION_SECRET is required in production')
-  }
-
-  return DEFAULT_DEV_SESSION_SECRET
+  return resolveJWTSecret()
 }
 
 export function resolveSecureCookie(): boolean {
-  const raw = process.env.AUTH_SECURE_COOKIE?.trim().toLowerCase()
-
-  if (raw === 'true' || raw === '1') return true
-  if (raw === 'false' || raw === '0') return false
-
-  return isProductionEnv()
+  return resolveSessionConfig().secure
 }

--- a/apps/web/src/server/auth.test.ts
+++ b/apps/web/src/server/auth.test.ts
@@ -7,54 +7,50 @@ afterEach(() => {
   vi.resetModules()
 })
 
-describe('server/auth env resolution', () => {
-  test('resolveSessionSecret uses env when set', async () => {
-    process.env.SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+describe('server/auth-config', () => {
+  test('resolveSessionSecret reads AUTH_JWT_SECRET', async () => {
+    process.env.AUTH_JWT_SECRET = 'my-jwt-secret-value'
 
     const { resolveSessionSecret } = await import('./auth-config')
-    expect(resolveSessionSecret()).toBe('0123456789abcdef0123456789abcdef')
+    expect(resolveSessionSecret()).toBe('my-jwt-secret-value')
   })
 
-  test('resolveSessionSecret falls back to dev secret outside production', async () => {
-    delete process.env.SESSION_SECRET
-    process.env.NODE_ENV = 'development'
+  test('resolveSessionSecret reads JWT_SECRET fallback', async () => {
+    delete process.env.AUTH_JWT_SECRET
+    process.env.JWT_SECRET = 'fallback-jwt-secret'
 
     const { resolveSessionSecret } = await import('./auth-config')
-    expect(resolveSessionSecret()).toBe('dev-session-secret-change-me')
+    expect(resolveSessionSecret()).toBe('fallback-jwt-secret')
   })
 
-  test('resolveSessionSecret throws when missing in production', async () => {
-    delete process.env.SESSION_SECRET
-    process.env.NODE_ENV = 'production'
+  test('resolveSessionSecret throws when no secret configured', async () => {
+    delete process.env.AUTH_JWT_SECRET
+    delete process.env.JWT_SECRET
 
     const { resolveSessionSecret } = await import('./auth-config')
-    expect(() => resolveSessionSecret()).toThrowError('SESSION_SECRET is required in production')
+    expect(() => resolveSessionSecret()).toThrowError('Missing JWT secret')
   })
 
-  test('resolveSecureCookie defaults true in production', async () => {
-    process.env.NODE_ENV = 'production'
-    delete process.env.AUTH_SECURE_COOKIE
+  test('resolveSecureCookie reads AUTH_SESSION_SECURE true', async () => {
+    process.env.AUTH_SESSION_SECURE = 'true'
 
     const { resolveSecureCookie } = await import('./auth-config')
     expect(resolveSecureCookie()).toBe(true)
   })
 
-  test('resolveSecureCookie defaults false in development', async () => {
-    process.env.NODE_ENV = 'development'
-    delete process.env.AUTH_SECURE_COOKIE
+  test('resolveSecureCookie reads SESSION_SECURE true', async () => {
+    delete process.env.AUTH_SESSION_SECURE
+    process.env.SESSION_SECURE = 'true'
 
     const { resolveSecureCookie } = await import('./auth-config')
-    expect(resolveSecureCookie()).toBe(false)
+    expect(resolveSecureCookie()).toBe(true)
   })
 
-  test('resolveSecureCookie allows explicit override', async () => {
-    process.env.NODE_ENV = 'production'
-    process.env.AUTH_SECURE_COOKIE = 'false'
+  test('resolveSecureCookie defaults to false', async () => {
+    delete process.env.AUTH_SESSION_SECURE
+    delete process.env.SESSION_SECURE
 
     const { resolveSecureCookie } = await import('./auth-config')
     expect(resolveSecureCookie()).toBe(false)
-
-    process.env.AUTH_SECURE_COOKIE = '1'
-    expect(resolveSecureCookie()).toBe(true)
   })
 })

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -1,26 +1,23 @@
 import '@tanstack/react-start/server-only'
 
-import { createDatabaseClient } from '@alesha-nov/db'
+import { createDatabaseClient, resolveDBType, runMigrations, authMigrationsBundle } from '@alesha-nov/db'
 import { createAuthService, getUserById } from '@alesha-nov/auth'
 import { getSessionFromRequest, type AuthSession } from '@alesha-nov/auth-web'
 import { createTanstackAuthHandler } from '@alesha-nov/auth-web/tanstack'
-import { resolveSecureCookie, resolveSessionSecret } from './auth-config'
-
-function resolveDbType(): 'mysql' | 'postgresql' | 'sqlite' {
-  const raw = process.env.DB_TYPE?.toLowerCase()
-  if (raw === 'mysql' || raw === 'postgresql' || raw === 'sqlite') return raw
-  if (raw === 'postgres') return 'postgresql'
-  return 'sqlite'
-}
+import { resolveSessionSecret, resolveSecureCookie } from './auth-config'
+import { createAuthEmailOptions } from './email'
 
 async function buildHandler() {
   const dbConfig = {
-    type: resolveDbType(),
+    type: resolveDBType(),
     url: process.env.DATABASE_URL ?? ':memory:',
   }
 
   const dbClient = createDatabaseClient(dbConfig)
-  const authService = await createAuthService(dbConfig, {}, dbClient)
+  await runMigrations(dbClient, authMigrationsBundle)
+
+  const emailOptions = createAuthEmailOptions()
+  const authService = await createAuthService(dbConfig, { email: emailOptions }, dbClient)
 
   return createTanstackAuthHandler({
     authService,

--- a/apps/web/src/server/email.ts
+++ b/apps/web/src/server/email.ts
@@ -1,0 +1,56 @@
+import { resolveEmailTransportConfig, resolveMagicLinkConfig } from '@alesha-nov/config'
+import {
+  createSesProvider,
+  createSmtpProvider,
+  withRetry,
+  withRateLimit,
+  type EmailProvider,
+} from '@alesha-nov/email'
+
+export interface AuthEmailOptions {
+  provider: EmailProvider
+  from: string
+}
+
+export function createAuthEmailOptions(): AuthEmailOptions | undefined {
+  const transportConfig = resolveEmailTransportConfig()
+  if (!transportConfig) return undefined
+
+  let provider: EmailProvider
+
+  if (transportConfig.type === 'ses') {
+    provider = createSesProvider({
+      region: transportConfig.ses!.region,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+    })
+  } else {
+    provider = createSmtpProvider({
+      host: transportConfig.smtp!.host,
+      port: transportConfig.smtp!.port,
+      secure: transportConfig.smtp!.secure,
+      user: transportConfig.smtp!.username ?? '',
+      pass: transportConfig.smtp!.password ?? '',
+    })
+  }
+
+  provider = withRetry(provider, {
+    maxAttempts: 3,
+    initialDelayMs: 200,
+    maxDelayMs: 5000,
+  })
+
+  provider = withRateLimit(provider, {
+    burstLimit: 10,
+    refillRatePerSecond: 1,
+  })
+
+  let from: string
+  try {
+    from = resolveMagicLinkConfig().sender
+  } catch {
+    from = process.env.AUTH_EMAIL_FROM ?? process.env.EMAIL_FROM ?? 'noreply@example.com'
+  }
+
+  return { provider, from }
+}


### PR DESCRIPTION
## Summary

Integrate `@alesha-nov/config` and `@alesha-nov/email` into `apps/web` to replace manual environment variable parsing with shared config resolvers and email providers.

Closes #78, Closes #79

## Changes

### `apps/web/src/server/auth-config.ts`
- Replaced manual `resolveSecureCookie`/`resolveSessionSecret` implementations with delegates to `resolveJWTSecret()` and `resolveSessionConfig()` from `@alesha-nov/config`
- Maintains the same exported interface (`resolveSessionSecret`, `resolveSecureCookie`)

### `apps/web/src/server/email.ts` (new)
- Creates `createAuthEmailOptions()` function
- Uses `resolveEmailTransportConfig()` from `@alesha-nov/config` to detect SES/SMTP transport
- Uses `createSesProvider`/`createSmtpProvider` from `@alesha-nov/email`
- Wraps provider with `withRetry` (3 attempts, exponential backoff) and `withRateLimit` (10 burst, 1/s refill)
- Returns `{ provider, from }` compatible with `AuthEmailOptions` from `@alesha-nov/auth`

### `apps/web/src/server/auth.ts`
- Replaces inline `resolveDbType()` with `resolveDBType()` from `@alesha-nov/db`
- Adds `runMigrations(dbClient, authMigrationsBundle)` call in `buildHandler` to ensure auth tables exist on startup
- Imports `createAuthEmailOptions` from `./email` and passes email options to `createAuthService`
- Keeps `getUser: (userId) => getUserById(dbClient, userId)`

### `apps/web/src/server/auth.test.ts`
- Updated tests to match new config-based env resolution (`AUTH_JWT_SECRET`/`JWT_SECRET` and `AUTH_SESSION_SECURE`/`SESSION_SECURE`)

## Test Results
- All 6 unit tests pass (`auth.test.ts`)
- Endpoint integration test skipped (requires Bun SQL runtime) — same as before
- TypeScript: no new errors