### PR TITLE
feat(web): Phase 3 — rate limiting and CORS (#83, #84)

### DIFF
--- a/.changeset/phase3-production-config.md
+++ b/.changeset/phase3-production-config.md
@@ -1,0 +1,9 @@
+---
+"@alesha-nov/web": minor
+---
+
+Configure rate limiting and CORS in auth handler
+
+- Add IP-based rate limiting (100 req/60s) via x-forwarded-for/x-real-ip
+- Add CORS configuration reading from ALLOWED_ORIGINS env var
+- Closes #83, #84

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -67,3 +67,10 @@ AUTH_EMAIL_SMTP_PASSWORD=
 # AUTH_OAUTH_GITHUB_CLIENT_ID=
 # AUTH_OAUTH_GITHUB_CLIENT_SECRET=
 # AUTH_OAUTH_GITHUB_REDIRECT_URI=http://localhost:3000/auth/callback/github
+
+# =============================================================================
+# CORS
+# =============================================================================
+# Comma-separated list of allowed origins (e.g., https://example.com,https://app.example.com)
+# Leave empty to disable CORS headers
+ALLOWED_ORIGINS=

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -25,6 +25,21 @@ async function buildHandler() {
     secureCookie: resolveSecureCookie(),
     sessionSecret: resolveSessionSecret(),
     getUser: (userId) => getUserById(dbClient, userId),
+    rateLimit: {
+      maxRequests: 100,
+      windowSeconds: 60,
+    },
+    getRateLimitKey: (request: Request) => {
+      const forwarded = request.headers.get('x-forwarded-for')
+      const realIp = request.headers.get('x-real-ip')
+      const ip = forwarded?.split(',')[0]?.trim() ?? realIp ?? 'unknown'
+      return ip
+    },
+    cors: {
+      allowedOrigins: process.env.ALLOWED_ORIGINS?.split(',').map((o) => o.trim()).filter(Boolean) ?? [],
+      allowedMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowCredentials: true,
+    },
   })
 }
 


### PR DESCRIPTION
## Changes
- Wire auth handler rate limiting in `apps/web/src/server/auth.ts` with `rateLimit: { maxRequests: 100, windowSeconds: 60 }`
- Add `getRateLimitKey(request)` to derive client IP from `x-forwarded-for` (first IP), fallback `x-real-ip`, then `unknown`
- Wire CORS options with exact `CorsOptions` fields from `@alesha-nov/auth-web`:
  - `allowedOrigins` from `ALLOWED_ORIGINS` (comma-separated env)
  - `allowedMethods`: `GET, POST, PUT, DELETE, OPTIONS`
  - `allowCredentials: true`
- Update `apps/web/.env.example` with `ALLOWED_ORIGINS` documentation
- Add changeset `.changeset/phase3-production-config.md`

## Verification
- `bun run build`
- `bun run lint`
- `bun run test`

Closes #83, #84
