### PR TITLE
feat(web): integrate TanStack Query for auth flows

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,8 @@
     "@alesha-nov/email": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",
+    "@tanstack/react-query": "latest",
+    "@tanstack/react-query-devtools": "latest",
     "@tanstack/react-router": "latest",
     "@tanstack/react-router-devtools": "latest",
     "@tanstack/react-router-ssr-query": "latest",

--- a/apps/web/src/query/auth.test.ts
+++ b/apps/web/src/query/auth.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { authUserQueryOptions, fetchAuthUser } from './auth'
+
+describe('auth query helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  test('fetchAuthUser returns session and user when both endpoints succeed', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ session: { userId: 'u1', email: 'a@example.com', roles: ['admin'], exp: 123 } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ user: { id: 'u1', email: 'a@example.com', name: 'Alice', image: null, emailVerifiedAt: null, createdAt: 'now', roles: ['admin'] } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchAuthUser({ basePath: '/auth' })
+
+    expect(result?.session.userId).toBe('u1')
+    expect(result?.user?.email).toBe('a@example.com')
+  })
+
+  test('fetchAuthUser returns null when session endpoint is unauthorized', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ user: { id: 'u1' } }), { status: 200 }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchAuthUser({ basePath: '/auth' })).resolves.toBeNull()
+  })
+
+  test('authUserQueryOptions includes stable key with base config', () => {
+    const options = authUserQueryOptions({ basePath: '/auth', baseUrl: 'http://localhost:3000' })
+
+    expect(options.queryKey).toEqual(['session-user', '/auth', 'http://localhost:3000'])
+  })
+})

--- a/apps/web/src/query/auth.test.tsx
+++ b/apps/web/src/query/auth.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  AUTH_USER_QUERY_KEY,
+  authUserQueryOptions,
+  fetchAuthUser,
+  useLoginMutation,
+  useLogoutMutation,
+  useRevokeSessionMutation,
+  useSignupMutation,
+} from './auth'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe('auth query helpers', () => {
+  test('fetchAuthUser returns auth payload when session exists', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ session: { userId: 'u-1', email: 'demo@example.com', roles: ['viewer'], exp: 9999999999 } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ user: { id: 'u-1', email: 'demo@example.com', name: null, image: null, emailVerifiedAt: null, createdAt: '2026-01-01', roles: ['viewer'] } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+
+    globalThis.fetch = fetchMock
+
+    const payload = await fetchAuthUser({ basePath: '/auth' })
+
+    expect(payload?.session.userId).toBe('u-1')
+    expect(payload?.user?.email).toBe('demo@example.com')
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/auth/session', { credentials: 'include' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/auth/me', { credentials: 'include' })
+  })
+
+  test('fetchAuthUser returns null when session endpoint is unauthorized', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+    fetchMock
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ user: { id: 'u-1' } }), { status: 200 }))
+
+    globalThis.fetch = fetchMock
+
+    const payload = await fetchAuthUser({ basePath: '/auth' })
+
+    expect(payload).toBeNull()
+  })
+
+  test('authUserQueryOptions includes scoped key parts', () => {
+    const options = authUserQueryOptions({ basePath: '/auth', baseUrl: 'https://example.com' })
+
+    expect(options.queryKey).toEqual([...AUTH_USER_QUERY_KEY, '/auth', 'https://example.com'])
+  })
+})
+
+describe('auth mutations', () => {
+  test('useLoginMutation posts to /login and invalidates auth cache', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: 'u-1', email: 'demo@example.com' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useLoginMutation({ basePath: '/auth' }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await result.current.mutateAsync({ email: 'demo@example.com', password: 'secret' })
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email: 'demo@example.com', password: 'secret' }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: AUTH_USER_QUERY_KEY })
+  })
+
+  test('useSignupMutation posts to /signup and invalidates auth cache', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ user: { id: 'u-2', email: 'new@example.com' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useSignupMutation({ basePath: '/auth' }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await result.current.mutateAsync({ email: 'new@example.com', password: 'secret', name: 'New User' })
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/auth/signup', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email: 'new@example.com', password: 'secret', name: 'New User' }),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: AUTH_USER_QUERY_KEY })
+  })
+
+  test('useLogoutMutation posts to /logout and invalidates auth cache', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useLogoutMutation({ basePath: '/auth' }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await result.current.mutateAsync()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/auth/logout', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({}),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: AUTH_USER_QUERY_KEY })
+  })
+
+  test('useRevokeSessionMutation posts to /sessions/revoke and invalidates auth cache', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const queryClient = new QueryClient()
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useRevokeSessionMutation({ basePath: '/auth' }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await result.current.mutateAsync()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/auth/sessions/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({}),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: AUTH_USER_QUERY_KEY })
+  })
+})

--- a/apps/web/src/query/auth.ts
+++ b/apps/web/src/query/auth.ts
@@ -1,0 +1,159 @@
+import type { AuthApiConfig, AuthSession, LoginInput, PublicUser, SignupInput } from '@alesha-nov/auth-react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+export type AuthUserData = {
+  session: AuthSession
+  user: PublicUser | null
+}
+
+export const AUTH_USER_QUERY_KEY = ["session-user"] as const
+
+const DEFAULT_CONFIG: AuthApiConfig = {
+  basePath: '/auth',
+}
+
+type NormalizedAuthConfig = Required<Pick<AuthApiConfig, 'basePath'>> & Pick<AuthApiConfig, 'baseUrl'>
+
+function normalizeConfig(config: AuthApiConfig): NormalizedAuthConfig {
+  return {
+    basePath: config.basePath ?? '/auth',
+    baseUrl: config.baseUrl,
+  }
+}
+
+function buildUrl(path: string, config: AuthApiConfig): string {
+  const normalized = normalizeConfig(config)
+  if (normalized.baseUrl) {
+    return `${normalized.baseUrl.replace(/\/+$/, '')}${normalized.basePath}${path}`
+  }
+
+  return `${normalized.basePath}${path}`
+}
+
+async function parseErrorMessage(response: Response): Promise<string> {
+  try {
+    const payload = (await response.json()) as { error?: string }
+    return payload.error ?? response.statusText ?? 'Request failed'
+  } catch {
+    return response.statusText || 'Request failed'
+  }
+}
+
+async function postJson<T>(path: string, body: unknown, config: AuthApiConfig): Promise<T> {
+  const response = await fetch(buildUrl(path, config), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response))
+  }
+
+  return response.json() as Promise<T>
+}
+
+async function fetchSession(config: AuthApiConfig): Promise<{ session: AuthSession } | null> {
+  const response = await fetch(buildUrl('/session', config), { credentials: 'include' })
+
+  if (!response.ok) {
+    return null
+  }
+
+  return response.json() as Promise<{ session: AuthSession }>
+}
+
+async function fetchMe(config: AuthApiConfig): Promise<{ user: PublicUser } | null> {
+  const response = await fetch(buildUrl('/me', config), { credentials: 'include' })
+
+  if (!response.ok) {
+    return null
+  }
+
+  return response.json() as Promise<{ user: PublicUser }>
+}
+
+export async function fetchAuthUser(config: AuthApiConfig = DEFAULT_CONFIG): Promise<AuthUserData | null> {
+  const [sessionData, meData] = await Promise.all([fetchSession(config), fetchMe(config)])
+
+  if (!sessionData?.session) {
+    return null
+  }
+
+  return {
+    session: sessionData.session,
+    user: meData?.user ?? null,
+  }
+}
+
+export function authUserQueryOptions(config: AuthApiConfig = DEFAULT_CONFIG) {
+  const normalized = normalizeConfig(config)
+
+  return {
+    queryKey: [...AUTH_USER_QUERY_KEY, normalized.basePath, normalized.baseUrl ?? ''] as const,
+    queryFn: () => fetchAuthUser(normalized),
+  }
+}
+
+export function useAuthUser(config: AuthApiConfig = DEFAULT_CONFIG) {
+  return useQuery(authUserQueryOptions(config))
+}
+
+async function invalidateAuthUser(queryClient: ReturnType<typeof useQueryClient>) {
+  await queryClient.invalidateQueries({ queryKey: AUTH_USER_QUERY_KEY })
+}
+
+export function useLoginMutation(config: AuthApiConfig = DEFAULT_CONFIG) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: LoginInput) => {
+      const response = await postJson<{ user: PublicUser }>('/login', input, config)
+      return response.user
+    },
+    onSuccess: async () => {
+      await invalidateAuthUser(queryClient)
+    },
+  })
+}
+
+export function useSignupMutation(config: AuthApiConfig = DEFAULT_CONFIG) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: SignupInput) => {
+      const response = await postJson<{ user: PublicUser }>('/signup', input, config)
+      return response.user
+    },
+    onSuccess: async () => {
+      await invalidateAuthUser(queryClient)
+    },
+  })
+}
+
+export function useLogoutMutation(config: AuthApiConfig = DEFAULT_CONFIG) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      await postJson<Record<string, unknown>>('/logout', {}, config)
+    },
+    onSuccess: async () => {
+      await invalidateAuthUser(queryClient)
+    },
+  })
+}
+
+export function useRevokeSessionMutation(config: AuthApiConfig = DEFAULT_CONFIG) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      await postJson<Record<string, unknown>>('/sessions/revoke', {}, config)
+    },
+    onSuccess: async () => {
+      await invalidateAuthUser(queryClient)
+    },
+  })
+}

--- a/apps/web/src/query/client.ts
+++ b/apps/web/src/query/client.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60,
+      gcTime: 1000 * 60 * 10,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})

--- a/apps/web/src/query/provider.tsx
+++ b/apps/web/src/query/provider.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { queryClient } from './client'
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}

--- a/apps/web/src/routes/-dashboard.before-load.test.ts
+++ b/apps/web/src/routes/-dashboard.before-load.test.ts
@@ -1,14 +1,30 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const getServerSessionOrNullMock = vi.fn<() => Promise<{ userId: string } | null>>()
+const prefetchQueryMock = vi.fn()
+const authUserQueryOptionsMock = vi.fn(() => ({ queryKey: ['auth-user', '/auth', ''] as const, queryFn: vi.fn() }))
 
 vi.mock('../server/session', () => ({
   getServerSessionOrNull: () => getServerSessionOrNullMock(),
 }))
 
+vi.mock('../query/client', () => ({
+  queryClient: {
+    prefetchQuery: (...args: unknown[]) => prefetchQueryMock(...args),
+  },
+}))
+
+vi.mock('../query/auth', () => ({
+  authUserQueryOptions: (...args: unknown[]) => authUserQueryOptionsMock(...args),
+  useAuthUser: () => ({ data: null }),
+  useLogoutMutation: () => ({ mutateAsync: vi.fn(), isPending: false, error: null }),
+}))
+
 describe('dashboard route beforeLoad', () => {
   beforeEach(() => {
     getServerSessionOrNullMock.mockReset()
+    prefetchQueryMock.mockReset()
+    authUserQueryOptionsMock.mockClear()
   })
 
   test('redirects unauthenticated requests to /login with redirect target', async () => {
@@ -40,5 +56,22 @@ describe('dashboard route beforeLoad', () => {
         location: { href: 'http://localhost:3000/dashboard' },
       } as never),
     ).resolves.toBeUndefined()
+  })
+
+  test('prefetches auth user query on client-side beforeLoad', async () => {
+    getServerSessionOrNullMock.mockResolvedValue({ userId: 'user-1' })
+
+    vi.stubGlobal('window', { document: {} })
+
+    const { Route } = await import('./dashboard')
+
+    await Route.options.beforeLoad?.({
+      location: { href: 'http://localhost:3000/dashboard' },
+    } as never)
+
+    expect(authUserQueryOptionsMock).toHaveBeenCalledWith({ basePath: '/auth' })
+    expect(prefetchQueryMock).toHaveBeenCalledTimes(1)
+
+    vi.unstubAllGlobals()
   })
 })

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { TanStackDevtools } from '@tanstack/react-devtools'
 import { AuthProvider } from '@alesha-nov/auth-react'
 import Footer from '../components/Footer'
 import Header from '../components/Header'
+import { QueryProvider } from '../query/provider'
 
 import appCss from '../styles.css?url'
 
@@ -27,9 +28,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body className="font-sans antialiased [overflow-wrap:anywhere] selection:bg-[rgba(79,184,178,0.24)]">
         <AuthProvider config={{ basePath: '/auth' }}>
-          <Header />
-          {children}
-          <Footer />
+          <QueryProvider>
+            <Header />
+            {children}
+            <Footer />
+          </QueryProvider>
         </AuthProvider>
         <TanStackDevtools
           config={{ position: 'bottom-right' }}

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
-import { AuthGuard, useAuth, useLogout } from '@alesha-nov/auth-react'
+import { AuthGuard } from '@alesha-nov/auth-react'
+import { authUserQueryOptions, useAuthUser, useLogoutMutation } from '../query/auth'
+import { queryClient } from '../query/client'
 import { getServerSessionOrNull } from '../server/session'
 
 export const Route = createFileRoute('/dashboard')({
@@ -12,13 +14,21 @@ export const Route = createFileRoute('/dashboard')({
         search: { redirect: location.href },
       })
     }
+
+    if (typeof window !== 'undefined') {
+      void queryClient.prefetchQuery(authUserQueryOptions({ basePath: '/auth' }))
+    }
   },
   component: DashboardPage,
 })
 
 function DashboardPage() {
-  const { user, session } = useAuth()
-  const { logout, loading, error } = useLogout({ basePath: '/auth' })
+  const authUserQuery = useAuthUser({ basePath: '/auth' })
+  const logoutMutation = useLogoutMutation({ basePath: '/auth' })
+
+  const user = authUserQuery.data?.user
+  const session = authUserQuery.data?.session
+  const error = logoutMutation.error instanceof Error ? logoutMutation.error.message : null
 
   return (
     <main className="page-wrap px-4 py-12">
@@ -27,8 +37,8 @@ function DashboardPage() {
           <h1 className="display-title mb-3 text-3xl font-bold">Dashboard (Protected)</h1>
           <p className="mb-2 text-sm text-[var(--sea-ink-soft)]">User: {user?.email}</p>
           <p className="mb-4 text-sm text-[var(--sea-ink-soft)]">Roles: {session?.roles.join(', ') || '-'}</p>
-          <button className="rounded-md border px-4 py-2" disabled={loading} onClick={() => void logout()} type="button">
-            {loading ? 'Logging out...' : 'Logout'}
+          <button className="rounded-md border px-4 py-2" disabled={logoutMutation.isPending} onClick={() => void logoutMutation.mutateAsync()} type="button">
+            {logoutMutation.isPending ? 'Logging out...' : 'Logout'}
           </button>
           {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
         </section>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link, redirect } from '@tanstack/react-router'
 import { useState } from 'react'
-import { useLogin, useMagicLinkRequest, useMagicLinkVerify, useAuth, useOAuthLogin } from '@alesha-nov/auth-react'
+import { useMagicLinkRequest, useMagicLinkVerify, useOAuthLogin } from '@alesha-nov/auth-react'
+import { useAuthUser, useLoginMutation } from '../query/auth'
 import { getServerSessionOrNull } from '../server/session'
 
 export const Route = createFileRoute('/login')({
@@ -14,11 +15,14 @@ export const Route = createFileRoute('/login')({
 })
 
 function LoginPage() {
-  const { login, loading, error } = useLogin({ basePath: '/auth' })
+  const loginMutation = useLoginMutation({ basePath: '/auth' })
+  const authUserQuery = useAuthUser({ basePath: '/auth' })
   const magicReq = useMagicLinkRequest({ basePath: '/auth' })
   const magicVerify = useMagicLinkVerify({ basePath: '/auth' })
   const { login: oauthLogin, loading: oauthLoading, error: oauthError } = useOAuthLogin({ basePath: '/auth' })
-  const { user } = useAuth()
+
+  const user = authUserQuery.data?.user
+  const loginError = loginMutation.error instanceof Error ? loginMutation.error.message : null
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -34,19 +38,19 @@ function LoginPage() {
             className="space-y-3"
             onSubmit={async (e) => {
               e.preventDefault()
-              await login({ email, password })
+              await loginMutation.mutateAsync({ email, password })
             }}
           >
             <input className="w-full rounded-md border p-2" placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
             <input className="w-full rounded-md border p-2" placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-            <button className="rounded-md border px-4 py-2" disabled={loading} type="submit">{loading ? 'Loading...' : 'Login'}</button>
+            <button className="rounded-md border px-4 py-2" disabled={loginMutation.isPending} type="submit">{loginMutation.isPending ? 'Loading...' : 'Login'}</button>
           </form>
           <p className="mt-3 text-sm text-[var(--sea-ink-soft)]">
             <Link to="/forgot-password" className="underline">
               Forgot password?
             </Link>
           </p>
-          {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+          {loginError ? <p className="mt-3 text-sm text-red-600">{loginError}</p> : null}
 
           <div className="mt-5 space-y-2 border-t pt-4">
             <button

--- a/apps/web/src/routes/settings/oauth-link.tsx
+++ b/apps/web/src/routes/settings/oauth-link.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { useAuth, useOAuthLink } from '@alesha-nov/auth-react'
+import { authUserQueryOptions } from '../../query/auth'
+import { queryClient } from '../../query/client'
 import { getServerSessionOrNull } from '../../server/session'
 
 type LinkedAccount = {
@@ -18,6 +20,10 @@ export const Route = createFileRoute('/settings/oauth-link')({
         to: '/login',
         search: { redirect: location.href },
       })
+    }
+
+    if (typeof window !== 'undefined') {
+      void queryClient.prefetchQuery(authUserQueryOptions({ basePath: '/auth' }))
     }
   },
   component: OAuthLinkSettingsPage,

--- a/apps/web/src/routes/settings/roles.tsx
+++ b/apps/web/src/routes/settings/roles.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useAuth } from '@alesha-nov/auth-react'
 import { useMemo, useState } from 'react'
+import { authUserQueryOptions } from '../../query/auth'
+import { queryClient } from '../../query/client'
 import { getServerSessionOrNull } from '../../server/session'
 
 const ADMIN_PERMISSIONS = new Set(['admin', 'roles:write:any'])
@@ -18,6 +20,10 @@ export const Route = createFileRoute('/settings/roles')({
     const canManageRoles = session.roles.some((role) => ADMIN_PERMISSIONS.has(role))
     if (!canManageRoles) {
       throw redirect({ to: '/dashboard' })
+    }
+
+    if (typeof window !== 'undefined') {
+      void queryClient.prefetchQuery(authUserQueryOptions({ basePath: '/auth' }))
     }
   },
   component: RolesSettingsPage,

--- a/apps/web/src/routes/settings/sessions.tsx
+++ b/apps/web/src/routes/settings/sessions.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
-import { useAuth, useLogout } from '@alesha-nov/auth-react'
 import { useState } from 'react'
+import { authUserQueryOptions, useAuthUser, useLogoutMutation, useRevokeSessionMutation } from '../../query/auth'
+import { queryClient } from '../../query/client'
 import { getServerSessionOrNull } from '../../server/session'
 
 export const Route = createFileRoute('/settings/sessions')({
@@ -12,38 +13,32 @@ export const Route = createFileRoute('/settings/sessions')({
         search: { redirect: location.href },
       })
     }
+
+    if (typeof window !== 'undefined') {
+      void queryClient.prefetchQuery(authUserQueryOptions({ basePath: '/auth' }))
+    }
   },
   component: SessionSettingsPage,
 })
 
 function SessionSettingsPage() {
-  const { session } = useAuth()
-  const { logout, loading: logoutLoading, error: logoutError } = useLogout({ basePath: '/auth' })
+  const authUserQuery = useAuthUser({ basePath: '/auth' })
+  const logoutMutation = useLogoutMutation({ basePath: '/auth' })
+  const revokeSessionMutation = useRevokeSessionMutation({ basePath: '/auth' })
 
-  const [revokeLoading, setRevokeLoading] = useState(false)
+  const session = authUserQuery.data?.session
+
   const [revokeAllLoading, setRevokeAllLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const revokeCurrentSession = async () => {
-    setRevokeLoading(true)
     setError(null)
 
     try {
-      const response = await fetch('/auth/sessions/revoke', {
-        method: 'POST',
-        credentials: 'include',
-      })
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => ({}))) as { error?: string }
-        throw new Error(payload.error ?? 'Failed to revoke current session')
-      }
-
-      await logout()
+      await revokeSessionMutation.mutateAsync()
+      await logoutMutation.mutateAsync()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to revoke current session')
-    } finally {
-      setRevokeLoading(false)
     }
   }
 
@@ -64,13 +59,16 @@ function SessionSettingsPage() {
         throw new Error(payload.error ?? 'Failed to revoke all sessions')
       }
 
-      await logout()
+      await logoutMutation.mutateAsync()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to revoke all sessions')
     } finally {
       setRevokeAllLoading(false)
     }
   }
+
+  const logoutError = logoutMutation.error instanceof Error ? logoutMutation.error.message : null
+  const revokeError = revokeSessionMutation.error instanceof Error ? revokeSessionMutation.error.message : null
 
   return (
     <main className="page-wrap px-4 py-12">
@@ -81,15 +79,16 @@ function SessionSettingsPage() {
         <p className="mb-5 text-sm text-[var(--sea-ink-soft)]">Roles: {session?.roles.join(', ') || '-'}</p>
 
         <div className="flex flex-wrap gap-3">
-          <button className="rounded-md border px-4 py-2" disabled={revokeLoading || logoutLoading} onClick={() => void revokeCurrentSession()} type="button">
-            {revokeLoading ? 'Revoking...' : 'Revoke Current Session'}
+          <button className="rounded-md border px-4 py-2" disabled={revokeSessionMutation.isPending || logoutMutation.isPending} onClick={() => void revokeCurrentSession()} type="button">
+            {revokeSessionMutation.isPending ? 'Revoking...' : 'Revoke Current Session'}
           </button>
-          <button className="rounded-md border px-4 py-2" disabled={revokeAllLoading || logoutLoading} onClick={() => void revokeAllSessions()} type="button">
+          <button className="rounded-md border px-4 py-2" disabled={revokeAllLoading || logoutMutation.isPending} onClick={() => void revokeAllSessions()} type="button">
             {revokeAllLoading ? 'Revoking...' : 'Revoke All Sessions'}
           </button>
         </div>
 
         {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+        {revokeError ? <p className="mt-3 text-sm text-red-600">{revokeError}</p> : null}
         {logoutError ? <p className="mt-3 text-sm text-red-600">{logoutError}</p> : null}
       </section>
     </main>

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useState } from 'react'
-import { useSignup } from '@alesha-nov/auth-react'
+import { useSignupMutation } from '../query/auth'
 import { getServerSessionOrNull } from '../server/session'
 
 export const Route = createFileRoute('/signup')({
@@ -14,7 +14,8 @@ export const Route = createFileRoute('/signup')({
 })
 
 function SignupPage() {
-  const { signup, loading, error, data } = useSignup({ basePath: '/auth' })
+  const signupMutation = useSignupMutation({ basePath: '/auth' })
+  const signupError = signupMutation.error instanceof Error ? signupMutation.error.message : null
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [name, setName] = useState('')
@@ -27,18 +28,18 @@ function SignupPage() {
           className="space-y-3"
           onSubmit={async (e) => {
             e.preventDefault()
-            await signup({ email, password, name })
+            await signupMutation.mutateAsync({ email, password, name })
           }}
         >
           <input className="w-full rounded-md border p-2" placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
           <input className="w-full rounded-md border p-2" placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
           <input className="w-full rounded-md border p-2" placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-          <button className="rounded-md border px-4 py-2" disabled={loading} type="submit">
-            {loading ? 'Creating...' : 'Create account'}
+          <button className="rounded-md border px-4 py-2" disabled={signupMutation.isPending} type="submit">
+            {signupMutation.isPending ? 'Creating...' : 'Create account'}
           </button>
         </form>
-        {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
-        {data ? <p className="mt-3 text-sm text-emerald-700">Signed up: {data.email}</p> : null}
+        {signupError ? <p className="mt-3 text-sm text-red-600">{signupError}</p> : null}
+        {signupMutation.data ? <p className="mt-3 text-sm text-emerald-700">Signed up: {signupMutation.data.email}</p> : null}
       </section>
     </main>
   )

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/web": {
       "name": "web",
-      "version": "0.1.6",
+      "version": "0.3.0",
       "dependencies": {
         "@alesha-nov/auth": "workspace:*",
         "@alesha-nov/auth-react": "workspace:*",
@@ -28,6 +28,8 @@
         "@alesha-nov/email": "workspace:*",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-devtools": "latest",
+        "@tanstack/react-query": "latest",
+        "@tanstack/react-query-devtools": "latest",
         "@tanstack/react-router": "latest",
         "@tanstack/react-router-devtools": "latest",
         "@tanstack/react-router-ssr-query": "latest",
@@ -58,15 +60,16 @@
     },
     "packages/auth": {
       "name": "@alesha-nov/auth",
-      "version": "0.2.4",
+      "version": "0.2.7",
       "dependencies": {
+        "@alesha-nov/config": "workspace:*",
         "@alesha-nov/db": "workspace:*",
         "@alesha-nov/email": "workspace:*",
       },
     },
     "packages/auth-react": {
       "name": "@alesha-nov/auth-react",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "devDependencies": {
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
@@ -81,18 +84,18 @@
     },
     "packages/auth-web": {
       "name": "@alesha-nov/auth-web",
-      "version": "0.2.4",
+      "version": "0.2.7",
       "dependencies": {
         "@alesha-nov/auth": "workspace:*",
       },
     },
     "packages/config": {
       "name": "@alesha-nov/config",
-      "version": "0.3.0",
+      "version": "0.3.1",
     },
     "packages/db": {
       "name": "@alesha-nov/db",
-      "version": "0.2.1",
+      "version": "0.2.2",
     },
     "packages/email": {
       "name": "@alesha-nov/email",
@@ -584,29 +587,33 @@
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.97.0", "", {}, "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.5", "", {}, "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg=="],
+
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.100.5", "", {}, "sha512-SuCkVCqqliRYJvm+LEL2U/TcFv92zTnHj6OGrJFHp1v/RsiwamI+ZDgQzbeUrLsJb8/Nj/52aIw0NyDMcVHl4A=="],
 
     "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.2", "", { "dependencies": { "@tanstack/devtools": "0.11.2" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-1BmZyxOrI5SqmRJ5MgkYZNNdnlLsJxQRI2YgorrAvcF2MxK6x5RcuStvD8+YlXoMw3JtNukPxoITirKAnKYDQA=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.97.0", "", { "dependencies": { "@tanstack/query-core": "5.97.0" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.5", "", { "dependencies": { "@tanstack/query-core": "5.100.5" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.22", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.15", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-W2LyfkfJtDCf//jOjZeUBWwOVl8iDRVTECpGHa2M28MT3T5/VVnjgicYNHR/ax0Filk1iU67MRjcjHheTYvK1Q=="],
+    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.100.5", "", { "dependencies": { "@tanstack/query-devtools": "5.100.5" }, "peerDependencies": { "@tanstack/react-query": "^5.100.5", "react": "^18 || ^19" } }, "sha512-bItQERx7dJoiI0WEoS4tIrvNnmk4kUYsaQLdIpm4o9Kttmsi5B6xlY6JBDkavstR3hH/R2+VT5dr3L5LBFPW4g=="],
+
+    "@tanstack/react-router": ["@tanstack/react-router@1.168.24", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.16", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-CQWd9ywDZU6icG65SrjJMzWcNg/ehBKFxfxYssKSuELk0eM9SzJxJ3JBI760kdLXIsXewOX9PHpJDknxC/R5Ag=="],
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.166.13", "", { "dependencies": { "@tanstack/router-devtools-core": "1.167.3" }, "peerDependencies": { "@tanstack/react-router": "^1.168.15", "@tanstack/router-core": "^1.168.11", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA=="],
 
-    "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.166.11", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.167.1" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-i81a5avRWgTjSKH5VYttbQ/Y86Il8GIkdcrIlyYUys0Lt1zMCxkTGHH9lBN5ZmhBe3mzwQ+9jOlx9xSxj8Kx0w=="],
+    "@tanstack/react-router-ssr-query": ["@tanstack/react-router-ssr-query@1.166.12", "", { "dependencies": { "@tanstack/router-ssr-query-core": "1.168.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/react-query": ">=5.90.0", "@tanstack/react-router": ">=1.127.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-yDUIoEh+PimAcWmk/2BE0EkI8TwLVeToNzoIuwahmTtBUR+ptZPWbtiPjudO8JZ0BhT3odHtuOn1eBOK0/4NAQ=="],
 
-    "@tanstack/react-start": ["@tanstack/react-start@1.167.41", "", { "dependencies": { "@tanstack/react-router": "1.168.22", "@tanstack/react-start-client": "1.166.39", "@tanstack/react-start-rsc": "0.0.20", "@tanstack/react-start-server": "1.166.40", "@tanstack/router-utils": "^1.161.6", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-plugin-core": "1.167.35", "@tanstack/start-server-core": "1.167.19", "pathe": "^2.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-w51yu/VQHNecIgN3ku+EmCxPjVbBftbnucDZBnxns43zPAhL5T5bnaBi0Fx4yJ3sDAmiceWEJD2F6IUaXTlNFA=="],
+    "@tanstack/react-start": ["@tanstack/react-start@1.167.49", "", { "dependencies": { "@tanstack/react-router": "1.168.24", "@tanstack/react-start-client": "1.166.42", "@tanstack/react-start-rsc": "0.0.28", "@tanstack/react-start-server": "1.166.43", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.19", "@tanstack/start-plugin-core": "1.169.5", "@tanstack/start-server-core": "1.167.21", "pathe": "^2.0.3" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"], "bin": { "intent": "bin/intent.js" } }, "sha512-zGIfVklhLHXeFPrAK7dCdjeFilAu+/ZC6+Hwq5ltMN/IXVmkddoSkDx9+63xYCMkHm+oujLd56phZ/kd3A2n3g=="],
 
-    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.39", "", { "dependencies": { "@tanstack/react-router": "1.168.22", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-NDao1nwwM4hXiVwQjVO8ZPlL9gZ0yeIl7w0PV+75jz+V9bhXr2nGhBuBw4zBuG7px4fEVmO5E8b7kpjWgCDJtA=="],
+    "@tanstack/react-start-client": ["@tanstack/react-start-client@1.166.42", "", { "dependencies": { "@tanstack/react-router": "1.168.24", "@tanstack/router-core": "1.168.16", "@tanstack/start-client-core": "1.167.19" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-p8i9HNvVz3QnzBMoVqx7qp1HaMzqiNStVpD+cOGlVi93cxx9CVMDZnOECwe5cIXVuAC3WW4+eB5+5vK8VEWdbg=="],
 
-    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.0.20", "", { "dependencies": { "@tanstack/react-router": "1.168.22", "@tanstack/react-start-server": "1.166.40", "@tanstack/router-core": "1.168.15", "@tanstack/router-utils": "1.161.6", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-plugin-core": "1.167.35", "@tanstack/start-server-core": "1.167.19", "@tanstack/start-storage-context": "1.166.29", "pathe": "^2.0.3" }, "peerDependencies": { "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@vitejs/plugin-rsc"] }, "sha512-KPsaq/asQxu/scMduMuQlwURIXwu+qZ7SO/8xbY/PQ/DJzfp9q1ZEHs9JN7dBEOHcme/YPeHta+UxBapB5Syyw=="],
+    "@tanstack/react-start-rsc": ["@tanstack/react-start-rsc@0.0.28", "", { "dependencies": { "@tanstack/react-router": "1.168.24", "@tanstack/react-start-server": "1.166.43", "@tanstack/router-core": "1.168.16", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.19", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-plugin-core": "1.169.5", "@tanstack/start-server-core": "1.167.21", "@tanstack/start-storage-context": "1.166.30", "pathe": "^2.0.3" }, "peerDependencies": { "@rspack/core": ">=2.0.0-0", "@vitejs/plugin-rsc": ">=0.5.20", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0", "react-server-dom-rspack": ">=0.0.2" }, "optionalPeers": ["@rspack/core", "@vitejs/plugin-rsc", "react-server-dom-rspack"] }, "sha512-rSEXRHAyP1iKTyzawdm2N44m1y9lP+f4K/BnTTGv2R9jPALmWXQZHWYw3mevjzGiXw2TTzQEZ0tJFuXc64MywQ=="],
 
-    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.40", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.168.22", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-server-core": "1.167.19" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-g5OU/eHmT1MleDbebdhNybpYgDu3QeNlemMCyXxEJNewOFM4iBlfoUBdMPhONJDlHQrOBXwMk/RUEFemY94yRw=="],
+    "@tanstack/react-start-server": ["@tanstack/react-start-server@1.166.43", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-router": "1.168.24", "@tanstack/router-core": "1.168.16", "@tanstack/start-client-core": "1.167.19", "@tanstack/start-server-core": "1.167.21" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-tfKFhDCiH8HNCwGFxkiuZsXIi68SHa+5/0i4bO7JCpPzy3FprVdcCJX0Vs0izaNcP8FVKs/TzRAzDilL42Tdlw=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.15", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.168.16", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-2lkWNMzDWWxVqTf9Y54DH1ceZOrGrOGzx9CFVMq8gQSOxhr3x3+otjVei1Rlx4xmsCc4yCqccqjun5wDtE9MZA=="],
 
     "@tanstack/router-devtools-core": ["@tanstack/router-devtools-core@1.167.3", "", { "dependencies": { "clsx": "^2.1.1", "goober": "^2.1.16" }, "peerDependencies": { "@tanstack/router-core": "^1.168.11", "csstype": "^3.0.10" }, "optionalPeers": ["csstype"] }, "sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg=="],
 
@@ -614,19 +621,19 @@
 
     "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.22", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.32", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.21", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-wYPzIvBK8bcmXVUpZfSgGBXOrfBAdF4odKevz6rejio5rEd947NtKDF5R7eYdwlAOmRqYpLJnJ1QHkc5t8bY4w=="],
 
-    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.167.1", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-sJNRHa36lfuHw04akO9C6KU1P1Ncam2Azsk5XlgdQHMFgOtSlFAsuwqAHpyYSwu5Jyxj6P3PmyKYMIm4u8dI7Q=="],
+    "@tanstack/router-ssr-query-core": ["@tanstack/router-ssr-query-core@1.168.0", "", { "peerDependencies": { "@tanstack/query-core": ">=5.90.0", "@tanstack/router-core": ">=1.127.0" } }, "sha512-5yBUAF1d9z2kOFKoz1spvpvkMSTmRnRXEwi+bGKfrXYmt7CfHu3Pk8KUFMln67uQoKQ9VTkcd5tLkjJVrZ2/AQ=="],
 
-    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
+    "@tanstack/router-utils": ["@tanstack/router-utils@1.161.7", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng=="],
 
-    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.17", "", { "dependencies": { "@tanstack/router-core": "1.168.15", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.29", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-3ZnpQ0LPnhrm/GX+HT7XfRxTcqnmBE1KJd7LtaJNuN13NH0C4ZOWchKLPEed2/gluhgsT6UgWm+Ec0kEFtxSaw=="],
+    "@tanstack/start-client-core": ["@tanstack/start-client-core@1.167.19", "", { "dependencies": { "@tanstack/router-core": "1.168.16", "@tanstack/start-fn-stubs": "1.161.6", "@tanstack/start-storage-context": "1.166.30", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-lyzA0hzSRKN+vl6093kX8GXnI4XVPDX5x5siWn0CGfmw4/+8l5dRU4Q7QVeWy7xu6JAZCV/gzdDs+nIm50YK7Q=="],
 
     "@tanstack/start-fn-stubs": ["@tanstack/start-fn-stubs@1.161.6", "", {}, "sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig=="],
 
-    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.167.35", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.15", "@tanstack/router-generator": "1.166.32", "@tanstack/router-plugin": "1.167.22", "@tanstack/router-utils": "1.161.6", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-server-core": "1.167.19", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.0", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "vite": ">=7.0.0" } }, "sha512-Ww511KfsXd7TbPYzjiUDCMUI5VbO0chmrTgFi1oOUT0jmk5U0Xh9WVIun1cvRmaq+KBZwvWGvmeIn0UwO3mHEA=="],
+    "@tanstack/start-plugin-core": ["@tanstack/start-plugin-core@1.169.5", "", { "dependencies": { "@babel/code-frame": "7.27.1", "@babel/core": "^7.28.5", "@babel/types": "^7.28.5", "@rolldown/pluginutils": "1.0.0-beta.40", "@tanstack/router-core": "1.168.16", "@tanstack/router-generator": "1.166.35", "@tanstack/router-plugin": "1.167.27", "@tanstack/router-utils": "1.161.7", "@tanstack/start-client-core": "1.167.19", "@tanstack/start-server-core": "1.167.21", "cheerio": "^1.0.0", "exsolve": "^1.0.7", "lightningcss": "^1.32.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "seroval": "^1.5.0", "source-map": "^0.7.6", "srvx": "^0.11.9", "tinyglobby": "^0.2.15", "ufo": "^1.5.4", "vitefu": "^1.1.1", "xmlbuilder2": "^4.0.3", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": "^2.0.0", "vite": ">=7.0.0" }, "optionalPeers": ["@rsbuild/core", "vite"] }, "sha512-gbPmbelQI7aLWxJn5M5XPoGvFKMf3rRU7J3RXNB9WO5lfrNVTEltKV6zBsW7HuJGxIspJRhsrA1c0AtjTsJAvw=="],
 
-    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.19", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.15", "@tanstack/start-client-core": "1.167.17", "@tanstack/start-storage-context": "1.166.29", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-wzOdfzLsK91CnjoywnEjXSlVlaRVK99HJhyVijNU1TECBI2JEKvW9S6d14YfS4gD4fFH4V86tFYhkcLPe6nzWg=="],
+    "@tanstack/start-server-core": ["@tanstack/start-server-core@1.167.21", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/router-core": "1.168.16", "@tanstack/start-client-core": "1.167.19", "@tanstack/start-storage-context": "1.166.30", "h3-v2": "npm:h3@2.0.1-rc.20", "seroval": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-G1tWw4lCCjPhyzUT+kMf2NyBS9i5mTlHoElvQBRYu2TvYbUStqnDhEha5apKWkuQWSucw2lM9V61JHucMFsZwg=="],
 
-    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.29", "", { "dependencies": { "@tanstack/router-core": "1.168.15" } }, "sha512-KrJYudc1nbnTY43jdN+hQFMYkhz7+3T+hkgBoGnIP1OspSe6vGQaYGDB4EUXYnkLfyQp+iUuKubgS8hSKeJ0ng=="],
+    "@tanstack/start-storage-context": ["@tanstack/start-storage-context@1.166.30", "", { "dependencies": { "@tanstack/router-core": "1.168.16" } }, "sha512-2hnpn1n2ls6NbsviNSLl/iD5y+WK45XGFgHDMUnzsUMEf5jXKUoQNSmmcjh+Lhtg+Ag7XOwOs4utXvm0OkevMQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -1422,13 +1429,25 @@
 
     "@tanstack/devtools-vite/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.168.15", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA=="],
+
+    "@tanstack/router-generator/@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
+
     "@tanstack/router-generator/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core": ["@tanstack/router-core@1.168.15", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA=="],
+
+    "@tanstack/router-plugin/@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
 
     "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-generator": ["@tanstack/router-generator@1.166.35", "", { "dependencies": { "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.16", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "jiti": "^2.6.1", "magic-string": "^0.30.21", "prettier": "^3.5.0", "zod": "^3.24.2" } }, "sha512-d3tdUTf6QRjMW4V2P91mE8OR0haHgGktkLOs3zQmirEokQhu2qgoVfcSxLF6DfmMR6smvDjwdeMdy2sudImuFQ=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.27", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.16", "@tanstack/router-generator": "1.166.35", "@tanstack/router-utils": "1.161.7", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^3.0.0", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2 || ^2.0.0", "@tanstack/react-router": "^1.168.24", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0", "vite-plugin-solid": "^2.11.10 || ^3.0.0-0", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-3jl+9I6bgSqAhwIDU2ps4pjhaEy2kugXvZ/dCAE6zF+pYEuRkNr8GA7bpoboZqdAtbceyZ2sLgX6aB7VQvHGUg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1502,6 +1521,12 @@
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "@tanstack/start-plugin-core/@tanstack/router-generator/prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
@@ -1528,10 +1553,16 @@
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "@tanstack/start-plugin-core/@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
   }
 }


### PR DESCRIPTION
## Summary
- add TanStack Query dependencies to `apps/web`
- add shared query client/provider and wire `QueryProvider` in `__root`
- implement auth query+mutation hooks (`useAuthUser`, `useLoginMutation`, `useSignupMutation`, `useLogoutMutation`, `useRevokeSessionMutation`) with cache invalidation
- prefetch auth query in protected `beforeLoad` routes (`dashboard`, `settings/sessions`, `settings/roles`, `settings/oauth-link`)
- migrate login/signup/sessions pages to query-based auth hooks and add/adjust tests

## Validation
- `bun run lint`
- `bun run test`

Closes #86
Closes #87
